### PR TITLE
Add setuptools config for py.typed and src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,12 @@ all = [
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+hmm = ["py.typed"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
## Summary
- Add setuptools package discovery config for src layout
- Include py.typed in package data for PEP 561 type checking support