### PR TITLE
Fix multiple bugs in HMM implementation

### DIFF
--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -190,7 +190,6 @@ def baum_welch(
     update_b: bool = True,
     scaling: bool = True,
     graph: bool = False,
-    norm_update: bool = False,
     fname: str = "ll.eps",
     verbose: bool = False,
 ) -> "HMM":
@@ -209,7 +208,6 @@ def baum_welch(
         update_b: flag to update observation emission probabilities (default: True)
         scaling: flag to scale probabilities (default: True, recommended)
         graph: flag to plot log-likelihoods (default: False)
-        norm_update: flag to use normalized update weights (default: False)
         fname: file name to save plot figure (default: "ll.eps")
         verbose: flag to print training progress (default: False)
 
@@ -246,10 +244,7 @@ def baum_welch(
             LL_epoch += log_prob_obs
             T = len(obs)
 
-            if norm_update:
-                w_k = 1.0 / -(log_prob_obs + np.log(len(obs)))
-            else:
-                w_k = 1.0
+            w_k = 1.0
 
             obs_symbols = obs[:]
             obs_indices = symbol_index(hmm, obs)
@@ -318,7 +313,7 @@ def baum_welch(
                 val_LL_epoch += forward(hmm=hmm, obs=val_obs, scaling=True)[0]
             val_LLs.append(val_LL_epoch)
 
-            if val_LL_epoch > (best_val_LL or float("-inf")):
+            if best_val_LL is None or val_LL_epoch > best_val_LL:
                 best_A = copy.deepcopy(hmm.A)
                 best_B = copy.deepcopy(hmm.B)
                 best_Pi = copy.deepcopy(hmm.Pi)
@@ -329,6 +324,8 @@ def baum_welch(
             print(f"Finished epoch {epoch + 1}, LL: {LL_epoch}")
             if val_set is not None:
                 print(f"  Validation LL: {val_LLs[epoch]}")
+                if epoch == best_epoch:
+                    print(f"  -> New best validation at epoch {epoch + 1}")
 
     if graph:
         import pylab  # type: ignore[import-untyped]

--- a/src/hmm/hmm.py
+++ b/src/hmm/hmm.py
@@ -180,13 +180,6 @@ class HMM:
         else:
             self.Labels = list(range(self.N))
 
-        if F is not None:
-            self.F = dict(F)
-            for i in self.F.keys():
-                self.B[i, :] = self.F[i]
-        else:
-            self.F = {}
-
     def __repr__(self) -> str:
         retn = ""
         retn += f"num hiddens: {self.N}\n"


### PR DESCRIPTION
## Summary
- Fix zero log-likelihood bug: Use explicit `None` check instead of `or` operator
- Remove duplicate F handling in `HMM.__init__`
- Remove non-standard `norm_update` heuristic (keep standard Baum-Welch as per Rabiner)
- Log `best_epoch` when `verbose=True` during validation

## Bug Details

### 1. Zero Log-Likelihood Bug
**File:** `src/hmm/algorithms.py:321`
- Changed `if val_LL_epoch > (best_val_LL or float("-inf"))` to `if best_val_LL is None or val_LL_epoch > best_val_LL`
- Fixes issue where `best_val_LL == 0.0` would incorrectly evaluate to `-inf`

### 2. Code Duplication in HMM.__init__
**File:** `src/hmm/hmm.py`
- Removed duplicate F (fixed emission probabilities) handling block at end of `__init__`

### 3. Remove norm_update
**File:** `src/hmm/algorithms.py`
- Removed non-standard `norm_update` parameter and heuristic
- Keeps implementation aligned with standard Rabiner (1989) formulation

### 4. Validation best_epoch Logging
**File:** `src/hmm/algorithms.py`
- Added logging of `best_epoch` when `verbose=True` during validation

## Test Plan
- [x] All existing tests pass (37 passed)
- [x] Ruff lint passes