### PR TITLE
Add GaussianHMM class for continuous emissions (Issue #20)

### DIFF
--- a/src/hmm/__init__.py
+++ b/src/hmm/__init__.py
@@ -2,6 +2,15 @@
 # Based on Rabiner tutorial
 
 from hmm.algorithms import backward, baum_welch, forward, viterbi
+from hmm.continuous import GaussianHMM
 from hmm.hmm import HMM, HMMClassifier
 
-__all__ = ["HMM", "HMMClassifier", "forward", "backward", "viterbi", "baum_welch"]
+__all__ = [
+    "HMM",
+    "HMMClassifier",
+    "GaussianHMM",
+    "forward",
+    "backward",
+    "viterbi",
+    "baum_welch",
+]

--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -35,18 +35,16 @@ def symbol_index(hmm: "HMM", obs: Sequence[int]) -> list[int]:
 
 def forward(
     hmm: "HMM",
-    obs: Sequence[int],
+    obs: Sequence[int] | Sequence[npt.NDArray],
     scaling: bool = True,
 ) -> tuple[float, npt.NDArray, npt.NDArray] | tuple[float, npt.NDArray]:
-    """
-    Calculate the probability of an observation sequence, Obs,
-    given the model, P(Obs|hmm).
+    """Calculate the probability of an observation sequence, Obs, given the model.
 
     Implements the forward algorithm from Rabiner (1989).
 
     Args:
-        hmm: the HMM model
-        obs: observation sequence
+        hmm: the HMM model (discrete HMM or GaussianHMM)
+        obs: observation sequence (integers for discrete, arrays for continuous)
         scaling: whether to use scaling (recommended for numerical stability)
 
     Returns:
@@ -60,22 +58,20 @@ def forward(
     """
     T = len(obs)
 
-    obs_indices = symbol_index(hmm, obs)
-
     c: npt.NDArray | None = None
     if scaling:
         c = np.zeros(T, dtype=float)
 
     alpha = np.zeros([hmm.N, T], dtype=float)
 
-    alpha[:, 0] = hmm.Pi * hmm.B[:, obs_indices[0]]
+    alpha[:, 0] = hmm.Pi * hmm.get_emission_probs(obs[0])
 
     if scaling and c is not None:
         c[0] = 1.0 / np.sum(alpha[:, 0])
         alpha[:, 0] = c[0] * alpha[:, 0]
 
     for t in range(1, T):
-        alpha[:, t] = np.dot(alpha[:, t - 1], hmm.A) * hmm.B[:, obs_indices[t]]
+        alpha[:, t] = np.dot(alpha[:, t - 1], hmm.A) * hmm.get_emission_probs(obs[t])
 
         if scaling and c is not None:
             c[t] = 1.0 / np.sum(alpha[:, t])
@@ -91,7 +87,7 @@ def forward(
 
 def backward(
     hmm: "HMM",
-    obs: Sequence[int],
+    obs: Sequence[int] | Sequence[npt.NDArray],
     c: npt.NDArray | None = None,
 ) -> npt.NDArray:
     """
@@ -110,15 +106,13 @@ def backward(
     """
     T = len(obs)
 
-    obs_indices = symbol_index(hmm, obs)
-
     beta = np.zeros([hmm.N, T], dtype=float)
     beta[:, T - 1] = 1.0
     if c is not None:
         beta[:, T - 1] = beta[:, T - 1] * c[T - 1]
 
     for t in reversed(range(T - 1)):
-        beta[:, t] = np.dot(hmm.A, (hmm.B[:, obs_indices[t + 1]] * beta[:, t + 1]))
+        beta[:, t] = np.dot(hmm.A, (hmm.get_emission_probs(obs[t + 1]) * beta[:, t + 1]))
 
         if c is not None:
             beta[:, t] = beta[:, t] * c[t]
@@ -128,7 +122,7 @@ def backward(
 
 def viterbi(
     hmm: "HMM",
-    obs: Sequence[int],
+    obs: Sequence[int] | Sequence[npt.NDArray],
     scaling: bool = True,
 ) -> tuple[list[int], npt.NDArray, npt.NDArray]:
     """
@@ -150,27 +144,25 @@ def viterbi(
     """
     T = len(obs)
 
-    obs_indices = symbol_index(hmm, obs)
-
     delta = np.zeros([hmm.N, T], dtype=float)
     eps = 1e-300  # Avoid log(0)
 
     if scaling:
-        delta[:, 0] = np.log(hmm.Pi + eps) + np.log(hmm.B[:, obs_indices[0]] + eps)
+        delta[:, 0] = np.log(hmm.Pi + eps) + np.log(hmm.get_emission_probs(obs[0]) + eps)
     else:
-        delta[:, 0] = hmm.Pi * hmm.B[:, obs_indices[0]]
+        delta[:, 0] = hmm.Pi * hmm.get_emission_probs(obs[0])
 
     psi = np.zeros([hmm.N, T], dtype=int)
 
     if scaling:
         for t in range(1, T):
             nus = rearrange(delta[:, t - 1], "n -> n 1") + np.log(hmm.A + eps)
-            delta[:, t] = nus.max(0) + np.log(hmm.B[:, obs_indices[t]] + eps)
+            delta[:, t] = nus.max(0) + np.log(hmm.get_emission_probs(obs[t]) + eps)
             psi[:, t] = nus.argmax(0)
     else:
         for t in range(1, T):
             nus = rearrange(delta[:, t - 1], "n -> n 1") * hmm.A
-            delta[:, t] = nus.max(0) * hmm.B[:, obs_indices[t]]
+            delta[:, t] = nus.max(0) * hmm.get_emission_probs(obs[t])
             psi[:, t] = nus.argmax(0)
 
     q_star = [int(np.argmax(delta[:, T - 1]))]
@@ -182,9 +174,9 @@ def viterbi(
 
 def baum_welch(
     hmm: "HMM",
-    obs_seqs: list[Sequence[int]],
+    obs_seqs: list[Sequence[int] | Sequence[npt.NDArray]],
     epochs: int = 20,
-    val_set: list[Sequence[int]] | None = None,
+    val_set: list[Sequence[int] | Sequence[npt.NDArray]] | None = None,
     update_pi: bool = True,
     update_a: bool = True,
     update_b: bool = True,
@@ -193,10 +185,12 @@ def baum_welch(
     fname: str = "ll.eps",
     verbose: bool = False,
 ) -> "HMM":
-    """
-    EM algorithm to update Pi, A, and B for the HMM.
+    """EM algorithm to update Pi, A, and B for the HMM.
 
     Implements the Baum-Welch algorithm from Rabiner (1989).
+
+    Note: For GaussianHMM, update_b=False is required (continuous emission
+    training not yet implemented).
 
     Args:
         hmm: HMM model to train
@@ -213,7 +207,19 @@ def baum_welch(
 
     Returns:
         Trained HMM model
+
+    Raises:
+        ValueError: if GaussianHMM is used with update_b=True
     """
+    # Check if this is a GaussianHMM (doesn't have M attribute)
+    is_gaussian = not hasattr(hmm, "M")
+
+    if is_gaussian and update_b:
+        raise ValueError(
+            "GaussianHMM training with update_b=True is not yet supported. "
+            "Use update_b=False to only update transition matrix and initial distribution."
+        )
+
     import copy
 
     LLs: list[float] = []
@@ -247,7 +253,6 @@ def baum_welch(
             w_k = 1.0
 
             obs_symbols = obs[:]
-            obs_indices = symbol_index(hmm, obs)
 
             gamma_raw = alpha * beta
             gamma = gamma_raw / gamma_raw.sum(0)
@@ -260,7 +265,10 @@ def baum_welch(
             for t in range(T - 1):
                 for i in range(hmm.N):
                     xi[i, :, t] = (
-                        alpha[i, t] * hmm.A[i, :] * hmm.B[:, obs_indices[t + 1]] * beta[:, t + 1]
+                        alpha[i, t]
+                        * hmm.A[i, :]
+                        * hmm.get_emission_probs(obs[t + 1])
+                        * beta[:, t + 1]
                     )
 
                 if not scaling:

--- a/src/hmm/continuous.py
+++ b/src/hmm/continuous.py
@@ -1,0 +1,130 @@
+"""Continuous Hidden Markov Model implementation."""
+
+import numpy as np
+import numpy.typing as npt
+from numpy import random as rand
+
+
+class GaussianHMM:
+    """
+    Continuous Hidden Markov Model with single multivariate Gaussian emissions per state.
+    Follows Rabiner (1989) Section VIII.
+
+    Attributes:
+        N: Number of hidden states
+        n_features: Dimensionality of the continuous observation vectors
+        A: Transition probability matrix (N x N)
+        Pi: Initial state distribution (N,)
+        means: Mean vectors for each state (N x n_features)
+        covars: Covariance matrices for each state (N x n_features x n_features)
+        Labels: State labels
+    """
+
+    def __init__(
+        self,
+        n_states: int = 1,
+        n_features: int = 1,
+        A: npt.NDArray | None = None,
+        Pi: npt.NDArray | None = None,
+        means: npt.NDArray | None = None,
+        covars: npt.NDArray | None = None,
+        Labels: list[int] | None = None,
+    ) -> None:
+        """Initialize a Continuous HMM with Gaussian emissions.
+
+        Args:
+            n_states: Number of hidden states
+            n_features: Dimensionality of observation vectors
+            A: Transition probability matrix (N x N)
+            Pi: Initial state distribution (N,)
+            means: Mean vectors (N x n_features)
+            covars: Covariance matrices (N x n_features x n_features)
+            Labels: State labels
+        """
+        self.N = n_states
+        self.n_features = n_features
+
+        # Initialize Transition Matrix A
+        if A is not None:
+            self.A = np.array(A, dtype=float)
+            assert np.shape(self.A) == (self.N, self.N)
+        else:
+            raw_A = rand.uniform(size=self.N * self.N).reshape((self.N, self.N))
+            self.A = (raw_A.T / raw_A.T.sum(0)).T
+            if n_states == 1:
+                self.A = self.A.reshape((1, 1))
+
+        # Initialize Initial Distribution Pi
+        if Pi is not None:
+            self.Pi = np.array(Pi, dtype=float)
+            assert len(self.Pi) == self.N
+        else:
+            self.Pi = np.array(1.0 / self.N).repeat(self.N)
+
+        # Initialize Continuous Emission Parameters (means and covariances)
+        if means is not None:
+            self.means = np.array(means, dtype=float)
+            assert self.means.shape == (self.N, self.n_features)
+        else:
+            self.means = rand.randn(self.N, self.n_features)
+
+        if covars is not None:
+            self.covars = np.array(covars, dtype=float)
+            assert self.covars.shape == (self.N, self.n_features, self.n_features)
+        else:
+            self.covars = np.array([np.eye(self.n_features) for _ in range(self.N)], dtype=float)
+
+        if Labels is not None:
+            self.Labels = list(Labels)
+        else:
+            self.Labels = list(range(self.N))
+
+    def emission_prob(self, state: int, obs: npt.NDArray) -> float:
+        """Calculate b_j(O) = N(O, mu_j, U_j).
+
+        Returns the probability density of observation vector 'obs' given 'state'.
+
+        Args:
+            state: State index (0 to N-1)
+            obs: Observation vector (n_features,)
+
+        Returns:
+            Probability density at obs
+        """
+        mu = self.means[state]
+        cov = self.covars[state]
+        d = self.n_features
+        diff = np.asarray(obs) - np.asarray(mu)
+
+        if d == 1:
+            diff_scalar = float(np.squeeze(diff))
+            var = float(np.squeeze(cov))
+            return float(np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(2 * np.pi * var))
+        else:
+            cov_inv = np.linalg.inv(cov)
+            det_cov = np.linalg.det(cov)
+            exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
+            return float(np.exp(exponent) / np.sqrt(((2 * np.pi) ** d) * det_cov))
+
+    def get_emission_probs(self, obs_t: npt.NDArray) -> npt.NDArray:
+        """Returns emission probabilities for all states given observation obs_t.
+
+        Args:
+            obs_t: Observation vector (n_features,)
+
+        Returns:
+            Array of shape (N,) with probability densities for each state
+        """
+        probs = np.zeros(self.N)
+        for i in range(self.N):
+            probs[i] = self.emission_prob(i, obs_t)
+        return probs
+
+    def __repr__(self) -> str:
+        retn = ""
+        retn += f"num hiddens: {self.N}\n"
+        retn += f"features (dimensions): {self.n_features}\n"
+        retn += f"\nA:\n {self.A}\n"
+        retn += f"Pi:\n {self.Pi}\n"
+        retn += f"Means:\n {self.means}\n"
+        return retn

--- a/src/hmm/hmm.py
+++ b/src/hmm/hmm.py
@@ -180,6 +180,17 @@ class HMM:
         else:
             self.Labels = list(range(self.N))
 
+    def get_emission_probs(self, obs_t: int) -> npt.NDArray:
+        """Returns emission probabilities for all states given observation obs_t.
+
+        Args:
+            obs_t: Observation symbol (must be in V)
+
+        Returns:
+            Array of shape (N,) with emission probabilities for each state
+        """
+        return self.B[:, self.symbol_map[obs_t]]
+
     def __repr__(self) -> str:
         retn = ""
         retn += f"num hiddens: {self.N}\n"

--- a/src/hmm/viz/diagrams.py
+++ b/src/hmm/viz/diagrams.py
@@ -106,12 +106,13 @@ def plot_gaussian_ellipses(
     cmap = plt.get_cmap("tab10")
     colors = [cmap(i % 10) for i in range(n_states)]
 
+    n_features = means.shape[1] if means.ndim > 1 else 1
+
     for i in range(n_states):
         mean = means[i]
         cov = covariances[i]
 
-        if mean.ndim == 2:
-            # 2D data: draw ellipses
+        if n_features == 2:
             eigenvalues, eigenvectors = np.linalg.eigh(cov)
             angle = np.degrees(np.arctan2(eigenvectors[1, 1], eigenvectors[0, 1]))
             width, height = 2 * n_std * np.sqrt(eigenvalues)
@@ -124,19 +125,21 @@ def plot_gaussian_ellipses(
                 alpha=0.3,
                 edgecolor=colors[i],
                 linewidth=2,
+                label=f"State {i}" if i == 0 else "",
             )
             ax.add_patch(ellipse)
             ax.plot(mean[0], mean[1], "o", color=colors[i], markersize=10)
-        else:
-            # 1D data: plot full Gaussian PDF
+        elif n_features == 1:
             std = float(np.sqrt(np.squeeze(cov)))
-            x = np.linspace(mean[0] - 4 * std, mean[0] + 4 * std, 200)
-            pdf = np.exp(-0.5 * ((x - mean[0]) / std) ** 2) / (std * np.sqrt(2 * np.pi))
-            ax.plot(x, pdf, color=colors[i], linewidth=2, label=f"State {i}")
-            ax.fill_between(x, pdf, alpha=0.2, color=colors[i])
+            mu = float(mean[0])
+            x_vals = np.linspace(mu - 4 * std, mu + 4 * std, 200)
+            pdf = np.exp(-0.5 * ((x_vals - mu) / std) ** 2) / (std * np.sqrt(2 * np.pi))
+            ax.plot(x_vals, pdf, color=colors[i], linewidth=2, label=f"State {i}" if i == 0 else "")
+            ax.fill_between(x_vals, 0, pdf, alpha=0.2, color=colors[i])
+            ax.axvline(mu, color=colors[i], linestyle="--", alpha=0.5)
 
     # Set labels based on dimensionality
-    if mean.ndim == 2:
+    if n_features == 2:
         ax.set_xlabel("Dimension 1")
         ax.set_ylabel("Dimension 2")
     else:
@@ -146,8 +149,7 @@ def plot_gaussian_ellipses(
     ax.set_title("Gaussian Emissions")
     ax.grid(True, alpha=0.3)
 
-    # Only set equal aspect for 2D
-    if mean.ndim == 2:
+    if n_features == 2:
         ax.set_aspect("equal")
 
     ax.legend()


### PR DESCRIPTION
## Summary
Initial implementation of continuous HMM support following Rabiner (1989) Section VIII.

### Changes

1. **Polymorphic Interface**: Added `get_emission_probs()` method to discrete HMM class to enable polymorphic algorithm usage

2. **GaussianHMM Class** (`src/hmm/continuous.py`):
   - Continuous HMM with single multivariate Gaussian emissions per state
   - Attributes: `n_features`, `means` (N x n_features), `covars` (N x n_features x n_features)
   - Methods: `emission_prob()`, `get_emission_probs()`

3. **Algorithm Updates** (`src/hmm/algorithms.py`):
   - Updated `forward()`, `backward()`, `viterbi()` to use polymorphic `get_emission_probs()`
   - Added check for GaussianHMM in `baum_welch()` - training with `update_b=True` raises error (not yet implemented)

4. **Visualization Fix** (`src/hmm/viz/diagrams.py`):
   - Fixed 1D Gaussian plotting with improved labels and legend handling

### Usage

```python
from hmm import GaussianHMM, forward, viterbi

# Create a 2-state GaussianHMM with 1D observations
hmm = GaussianHMM(n_states=2, n_features=1)
hmm.means = np.array([[0.0], [5.0]])
hmm.covars = np.array([[[1.0]], [[1.0]]])

# Run forward algorithm with continuous observations
obs = [np.array([0.1]), np.array([0.2]), np.array([4.9])]
log_prob, alpha, c = forward(hmm, obs, scaling=True)

# Run Viterbi
states, delta, psi = viterbi(hmm, obs, scaling=True)
```

### Limitations
- GaussianHMM training (Baum-Welch with emission updates) not yet implemented
- Use `update_b=False` to train only transition matrix and initial distribution

## Test Plan
- [x] All existing tests pass (37 passed)
- [x] Ruff lint passes
- [x] Manual test of GaussianHMM with forward/viterbi