### PR TITLE
Add MixtureGaussianHMM class with Baum-Welch support

### DIFF
--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -220,10 +220,16 @@ def baum_welch(
     best_epoch = -1
     best_val_LL = float("-inf") if val_set is not None else None
 
+    # Check if this is a MixtureGaussianHMM (has n_mixtures attribute)
+    is_mixture = hasattr(hmm, "n_mixtures") and hmm.n_mixtures > 1
+    is_continuous = is_gaussian  # Both GaussianHMM and MixtureGaussianHMM are continuous
+
     # For GaussianHMM: store best means and covariances for validation
-    if is_gaussian:
+    if is_continuous:
         best_means = copy.deepcopy(hmm.means)
         best_covars = copy.deepcopy(hmm.covars)
+        if is_mixture:
+            best_weights = copy.deepcopy(hmm.weights)
     else:
         best_B = copy.deepcopy(hmm.B)
 
@@ -236,9 +242,16 @@ def baum_welch(
         expect_si_t0_all = np.zeros(hmm.N, dtype=float)
 
         # For GaussianHMM: accumulators for means and covariances
-        if is_gaussian:
-            expect_obs_sum = np.zeros([hmm.N, hmm.n_features], dtype=float)
-            expect_obs_cov = np.zeros([hmm.N, hmm.n_features, hmm.n_features], dtype=float)
+        if is_continuous:
+            if is_mixture:
+                expect_mix_sum = np.zeros([hmm.N, hmm.n_mixtures], dtype=float)
+                expect_obs_sum = np.zeros([hmm.N, hmm.n_mixtures, hmm.n_features], dtype=float)
+                expect_obs_cov = np.zeros(
+                    [hmm.N, hmm.n_mixtures, hmm.n_features, hmm.n_features], dtype=float
+                )
+            else:
+                expect_obs_sum = np.zeros([hmm.N, hmm.n_features], dtype=float)
+                expect_obs_cov = np.zeros([hmm.N, hmm.n_features, hmm.n_features], dtype=float)
         else:
             expect_si_vk_all = np.zeros([hmm.N, hmm.M], dtype=float)
 
@@ -281,14 +294,59 @@ def baum_welch(
             expect_si_sj_all_TM1 += w_k * xi[:, :, : T - 1].sum(2)
 
             if update_b:
-                if is_gaussian:
-                    # Accumulate weighted observations for means/covariances update
+                if is_continuous:
+                    # For continuous HMM: accumulate weighted observations
+                    # gamma_jk_t = gamma[j,t] * c_jk * N(O_t | mu_jk, sigma_jk) / b_j(O_t)
                     for t in range(T):
                         obs_t = np.asarray(obs[t])
-                        for j in range(hmm.N):
-                            expect_obs_sum[j] += gamma[j, t] * obs_t
-                            diff = obs_t - hmm.means[j]
-                            expect_obs_cov[j] += gamma[j, t] * np.outer(diff, diff)
+                        b_j = hmm.get_emission_probs(obs_t)
+
+                        if is_mixture:
+                            # Mixture Gaussian case
+                            for j in range(hmm.N):
+                                for k in range(hmm.n_mixtures):
+                                    c_jk = hmm.weights[j, k]
+                                    mu_jk = hmm.means[j, k]
+                                    sigma_jk = hmm.covars[j, k]
+
+                                    # Gaussian PDF for this mixture component
+                                    diff = np.asarray(obs_t) - np.asarray(mu_jk)
+                                    if hmm.n_features == 1:
+                                        diff_scalar = float(diff.flatten()[0])
+                                        sigma_jk_arr = np.asarray(sigma_jk).flatten()
+                                        var = float(sigma_jk_arr[0])
+                                        pdf = np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(
+                                            2 * np.pi * var
+                                        )
+                                    else:
+                                        cov_inv = np.linalg.inv(sigma_jk)
+                                        det_cov = np.linalg.det(sigma_jk)
+                                        exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
+                                        pdf = np.exp(exponent) / np.sqrt(
+                                            ((2 * np.pi) ** hmm.n_features) * det_cov
+                                        )
+                                    cov_inv = np.linalg.inv(sigma_jk)
+                                    det_cov = np.linalg.det(sigma_jk)
+                                    exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
+                                    pdf = np.exp(exponent) / np.sqrt(
+                                        ((2 * np.pi) ** hmm.n_features) * det_cov
+                                    )
+
+                                if b_j[j] > 0:
+                                    gamma_jk = gamma[j, t] * c_jk * pdf / b_j[j]
+                                else:
+                                    gamma_jk = 0.0
+
+                                expect_mix_sum[j, k] += gamma_jk
+                                expect_obs_sum[j, k] += gamma_jk * obs_t
+                                diff_outer = np.outer(diff, diff)
+                                expect_obs_cov[j, k] += gamma_jk * diff_outer
+                        else:
+                            # Single Gaussian case
+                            for j in range(hmm.N):
+                                expect_obs_sum[j] += gamma[j, t] * obs_t
+                                diff = obs_t - hmm.means[j]
+                                expect_obs_cov[j] += gamma[j, t] * np.outer(diff, diff)
                 else:
                     # Discrete B matrix update
                     B_bar = np.zeros([hmm.N, hmm.M], dtype=float)
@@ -309,16 +367,34 @@ def baum_welch(
             hmm.A = A_bar
 
         if update_b:
-            if is_gaussian:
-                # Update means (Rabiner Eq. 53)
-                for j in range(hmm.N):
-                    if expect_si_all[j] > 0:
-                        hmm.means[j] = expect_obs_sum[j] / expect_si_all[j]
+            if is_continuous:
+                if is_mixture:
+                    # Update mixture weights (Rabiner Eq. 52)
+                    for j in range(hmm.N):
+                        if expect_si_all[j] > 0:
+                            hmm.weights[j, :] = expect_mix_sum[j, :] / expect_si_all[j]
 
-                # Update covariances (Rabiner Eq. 54)
-                for j in range(hmm.N):
-                    if expect_si_all[j] > 0:
-                        hmm.covars[j] = expect_obs_cov[j] / expect_si_all[j]
+                    # Update means (Rabiner Eq. 53)
+                    for j in range(hmm.N):
+                        for k in range(hmm.n_mixtures):
+                            if expect_mix_sum[j, k] > 0:
+                                hmm.means[j, k] = expect_obs_sum[j, k] / expect_mix_sum[j, k]
+
+                    # Update covariances (Rabiner Eq. 54)
+                    for j in range(hmm.N):
+                        for k in range(hmm.n_mixtures):
+                            if expect_mix_sum[j, k] > 0:
+                                hmm.covars[j, k] = expect_obs_cov[j, k] / expect_mix_sum[j, k]
+                else:
+                    # Single Gaussian case - Update means (Rabiner Eq. 53)
+                    for j in range(hmm.N):
+                        if expect_si_all[j] > 0:
+                            hmm.means[j] = expect_obs_sum[j] / expect_si_all[j]
+
+                    # Update covariances (Rabiner Eq. 54)
+                    for j in range(hmm.N):
+                        if expect_si_all[j] > 0:
+                            hmm.covars[j] = expect_obs_cov[j] / expect_si_all[j]
             else:
                 # Discrete B matrix update
                 for i in range(hmm.N):
@@ -348,9 +424,11 @@ def baum_welch(
             if best_val_LL is None or val_LL_epoch > best_val_LL:
                 best_A = copy.deepcopy(hmm.A)
                 best_Pi = copy.deepcopy(hmm.Pi)
-                if is_gaussian:
+                if is_continuous:
                     best_means = copy.deepcopy(hmm.means)
                     best_covars = copy.deepcopy(hmm.covars)
+                    if is_mixture:
+                        best_weights = copy.deepcopy(hmm.weights)
                 else:
                     best_B = copy.deepcopy(hmm.B)
                 best_epoch = epoch
@@ -395,6 +473,10 @@ def baum_welch(
         hmm.Pi = best_Pi
         if hasattr(hmm, "B"):
             hmm.B = best_B
+        elif hasattr(hmm, "weights"):
+            hmm.means = best_means
+            hmm.covars = best_covars
+            hmm.weights = best_weights
         else:
             hmm.means = best_means
             hmm.covars = best_covars

--- a/src/hmm/continuous.py
+++ b/src/hmm/continuous.py
@@ -128,3 +128,164 @@ class GaussianHMM:
         retn += f"Pi:\n {self.Pi}\n"
         retn += f"Means:\n {self.means}\n"
         return retn
+
+
+class MixtureGaussianHMM:
+    """
+    Continuous Hidden Markov Model with mixture of Gaussian emissions per state.
+    Follows Rabiner (1989) Section VIII, Equations 49-54.
+
+    Attributes:
+        N: Number of hidden states
+        n_features: Dimensionality of the continuous observation vectors
+        n_mixtures: Number of Gaussian mixtures per state
+        A: Transition probability matrix (N x N)
+        Pi: Initial state distribution (N,)
+        weights: Mixture weights for each state (N x n_mixtures)
+        means: Mean vectors for each state and mixture (N x n_mixtures x n_features)
+        covars: Covariance matrices (N x n_mixtures x n_features x n_features)
+        Labels: State labels
+    """
+
+    def __init__(
+        self,
+        n_states: int = 1,
+        n_features: int = 1,
+        n_mixtures: int = 1,
+        A: npt.NDArray | None = None,
+        Pi: npt.NDArray | None = None,
+        weights: npt.NDArray | None = None,
+        means: npt.NDArray | None = None,
+        covars: npt.NDArray | None = None,
+        Labels: list[int] | None = None,
+    ) -> None:
+        """Initialize a Mixture Gaussian HMM.
+
+        Args:
+            n_states: Number of hidden states
+            n_features: Dimensionality of observation vectors
+            n_mixtures: Number of Gaussian mixtures per state
+            A: Transition probability matrix (N x N)
+            Pi: Initial state distribution (N,)
+            weights: Mixture weights (N x n_mixtures)
+            means: Mean vectors (N x n_mixtures x n_features)
+            covars: Covariance matrices (N x n_mixtures x n_features x n_features)
+            Labels: State labels
+        """
+        self.N = n_states
+        self.n_features = n_features
+        self.n_mixtures = n_mixtures
+
+        if A is not None:
+            self.A = np.array(A, dtype=float)
+            assert np.shape(self.A) == (self.N, self.N)
+        else:
+            raw_A = rand.uniform(size=self.N * self.N).reshape((self.N, self.N))
+            self.A = (raw_A.T / raw_A.T.sum(0)).T
+            if n_states == 1:
+                self.A = self.A.reshape((1, 1))
+
+        if Pi is not None:
+            self.Pi = np.array(Pi, dtype=float)
+            assert len(self.Pi) == self.N
+        else:
+            self.Pi = np.array(1.0 / self.N).repeat(self.N)
+
+        if weights is not None:
+            self.weights = np.array(weights, dtype=float)
+            assert self.weights.shape == (self.N, self.n_mixtures)
+        else:
+            raw_weights = rand.uniform(size=self.N * self.n_mixtures).reshape(
+                (self.N, self.n_mixtures)
+            )
+            self.weights = raw_weights / raw_weights.sum(axis=1, keepdims=True)
+
+        if means is not None:
+            self.means = np.array(means, dtype=float)
+            assert self.means.shape == (self.N, self.n_mixtures, self.n_features)
+        else:
+            self.means = rand.randn(self.N, self.n_mixtures, self.n_features)
+
+        if covars is not None:
+            self.covars = np.array(covars, dtype=float)
+            assert self.covars.shape == (self.N, self.n_mixtures, self.n_features, self.n_features)
+        else:
+            self.covars = np.array(
+                [[np.eye(self.n_features) for _ in range(self.n_mixtures)] for _ in range(self.N)],
+                dtype=float,
+            )
+
+        if Labels is not None:
+            self.Labels = list(Labels)
+        else:
+            self.Labels = list(range(self.N))
+
+    def _gaussian_pdf(self, mean: npt.NDArray, cov: npt.NDArray, obs: npt.NDArray) -> float:
+        """Calculate Gaussian PDF for multivariate case.
+
+        Args:
+            mean: Mean vector (n_features,)
+            cov: Covariance matrix (n_features x n_features)
+            obs: Observation vector (n_features,)
+
+        Returns:
+            Probability density
+        """
+        d = self.n_features
+        diff = np.asarray(obs) - np.asarray(mean)
+
+        if d == 1:
+            diff_scalar = float(np.squeeze(diff))
+            var = float(np.squeeze(cov))
+            return float(np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(2 * np.pi * var))
+        else:
+            cov_inv = np.linalg.inv(cov)
+            det_cov = np.linalg.det(cov)
+            exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
+            return float(np.exp(exponent) / np.sqrt(((2 * np.pi) ** d) * det_cov))
+
+    def emission_prob(self, state: int, obs: npt.NDArray) -> float:
+        """Calculate b_j(O) = sum_k c_jk * N(O, mu_jk, U_jk).
+
+        Returns the probability density of observation vector 'obs' given 'state'
+        using mixture of Gaussians.
+
+        Args:
+            state: State index (0 to N-1)
+            obs: Observation vector (n_features,)
+
+        Returns:
+            Probability density at obs
+        """
+        density = 0.0
+        for k in range(self.n_mixtures):
+            c_jk = self.weights[state, k]
+            mu_jk = self.means[state, k]
+            cov_jk = self.covars[state, k]
+            density += c_jk * self._gaussian_pdf(mu_jk, cov_jk, obs)
+        return density
+
+    def get_emission_probs(self, obs_t: npt.NDArray) -> npt.NDArray:
+        """Returns emission probabilities for all states given observation obs_t.
+
+        Args:
+            obs_t: Observation vector (n_features,)
+
+        Returns:
+            Array of shape (N,) with probability densities for each state
+        """
+        probs = np.zeros(self.N)
+        for i in range(self.N):
+            probs[i] = self.emission_prob(i, obs_t)
+        return probs
+
+    def __repr__(self) -> str:
+        retn = ""
+        retn += f"num hiddens: {self.N}\n"
+        retn += f"features (dimensions): {self.n_features}\n"
+        retn += f"num mixtures: {self.n_mixtures}\n"
+        retn += f"\nA:\n {self.A}\n"
+        retn += f"Pi:\n {self.Pi}\n"
+        retn += f"Weights:\n {self.weights}\n"
+        retn += f"Means:\n {self.means}\n"
+        return retn

--- a/tests/test_mixture_gaussian_hmm.py
+++ b/tests/test_mixture_gaussian_hmm.py
@@ -1,0 +1,159 @@
+"""Tests for MixtureGaussianHMM class."""
+
+import numpy as np
+
+from hmm.continuous import MixtureGaussianHMM
+
+
+class TestMixtureGaussianHMMClass:
+    """Tests for MixtureGaussianHMM class."""
+
+    def test_create_mixture_gaussian_hmm(self) -> None:
+        """Test creating MixtureGaussianHMM with provided parameters."""
+        n_states = 2
+        n_features = 1
+        n_mixtures = 3
+
+        A = np.array([[0.95, 0.05], [0.05, 0.95]])
+        Pi = np.array([0.5, 0.5])
+        weights = np.array([[0.5, 0.3, 0.2], [0.2, 0.5, 0.3]])
+        means = np.array([[[0.0], [5.0], [10.0]], [[15.0], [20.0], [25.0]]])
+        covars = np.array([[[[1.0]], [[2.0]], [[3.0]]], [[[1.0]], [[2.0]], [[3.0]]]])
+
+        hmm = MixtureGaussianHMM(
+            n_states=n_states,
+            n_features=n_features,
+            n_mixtures=n_mixtures,
+            A=A,
+            Pi=Pi,
+            weights=weights,
+            means=means,
+            covars=covars,
+        )
+
+        assert hmm.N == n_states
+        assert hmm.n_features == n_features
+        assert hmm.n_mixtures == n_mixtures
+        assert np.allclose(hmm.A, A)
+        assert np.allclose(hmm.Pi, Pi)
+        assert np.allclose(hmm.weights, weights)
+        assert np.allclose(hmm.means, means)
+        assert np.allclose(hmm.covars, covars)
+
+    def test_create_mixture_gaussian_hmm_random_init(self) -> None:
+        """Test creating MixtureGaussianHMM with random initialization."""
+        hmm = MixtureGaussianHMM(n_states=2, n_features=1, n_mixtures=2)
+
+        assert hmm.N == 2
+        assert hmm.n_features == 1
+        assert hmm.n_mixtures == 2
+        assert hmm.A.shape == (2, 2)
+        assert hmm.Pi.shape == (2,)
+        assert hmm.weights.shape == (2, 2)
+        assert hmm.means.shape == (2, 2, 1)
+        assert hmm.covars.shape == (2, 2, 1, 1)
+
+    def test_weights_sum_to_one(self) -> None:
+        """Test that mixture weights sum to 1 for each state."""
+        hmm = MixtureGaussianHMM(n_states=2, n_features=1, n_mixtures=3)
+
+        for i in range(hmm.N):
+            assert np.isclose(hmm.weights[i].sum(), 1.0)
+
+
+class TestMixtureGaussianEmission:
+    """Tests for mixture emission probability calculations."""
+
+    def test_emission_prob_single_mixture(self) -> None:
+        """Test emission probability calculation with single mixture per state."""
+        n_states = 1
+        n_features = 1
+        n_mixtures = 1
+
+        means = np.array([[[0.0]]])
+        covars = np.array([[[[1.0]]]])
+        weights = np.array([[1.0]])
+
+        hmm = MixtureGaussianHMM(
+            n_states=n_states,
+            n_features=n_features,
+            n_mixtures=n_mixtures,
+            means=means,
+            covars=covars,
+            weights=weights,
+        )
+
+        prob = hmm.emission_prob(0, np.array([0.0]))
+        expected = 1.0 / np.sqrt(2 * np.pi)
+        assert np.isclose(prob, expected, rtol=1e-5)
+
+    def test_emission_prob_multiple_mixtures(self) -> None:
+        """Test emission probability with multiple mixtures."""
+        n_states = 1
+        n_features = 1
+        n_mixtures = 2
+
+        means = np.array([[[0.0], [5.0]]])
+        covars = np.array([[[[1.0]], [[0.5]]]])
+        weights = np.array([[0.7, 0.3]])
+
+        hmm = MixtureGaussianHMM(
+            n_states=n_states,
+            n_features=n_features,
+            n_mixtures=n_mixtures,
+            means=means,
+            covars=covars,
+            weights=weights,
+        )
+
+        prob_at_zero = hmm.emission_prob(0, np.array([0.0]))
+        prob_at_five = hmm.emission_prob(0, np.array([5.0]))
+
+        assert prob_at_zero > 0
+        assert prob_at_five > 0
+
+    def test_get_emission_probs_shape(self) -> None:
+        """Test get_emission_probs returns correct shape."""
+        hmm = MixtureGaussianHMM(n_states=2, n_features=1, n_mixtures=3)
+
+        probs = hmm.get_emission_probs(np.array([0.0]))
+
+        assert probs.shape == (2,)
+
+
+class TestMixtureGaussianHMMTraining:
+    """Tests for MixtureGaussianHMM training."""
+
+    def test_baum_welch_training(self) -> None:
+        """Test Baum-Welch training updates mixture parameters."""
+        np.random.seed(42)
+        true_means = np.array([[[-2.0], [2.0]], [[-2.0], [2.0]]])
+        true_covars = np.array([[[[0.5]]], [[[0.5]]]])
+        true_weights = np.array([[0.5, 0.5], [0.5, 0.5]])
+
+        hmm = MixtureGaussianHMM(n_states=2, n_features=1, n_mixtures=2)
+        hmm.means = true_means.copy()
+        hmm.covars = true_covars.copy()
+        hmm.weights = true_weights.copy()
+
+        obs = []
+        for _ in range(30):
+            state = np.random.choice(2, p=hmm.Pi)
+            for _ in range(10):
+                obs.append(
+                    hmm.means[state, 0, 0] + np.sqrt(hmm.covars[state, 0, 0, 0]) * np.random.randn()
+                )
+        obs = np.array(obs).reshape(-1, 1)
+
+        hmm2 = MixtureGaussianHMM(n_states=2, n_features=1, n_mixtures=2)
+        initial_means = hmm2.means.copy()
+        initial_weights = hmm2.weights.copy()
+
+        from hmm.algorithms import baum_welch
+
+        trained = baum_welch(hmm2, [obs], epochs=10, update_a=True, update_b=True, verbose=False)
+
+        means_changed = not np.allclose(trained.means, initial_means)
+        weights_changed = not np.allclose(trained.weights, initial_weights)
+
+        assert means_changed or weights_changed


### PR DESCRIPTION
## Summary

- Add `MixtureGaussianHMM` class with mixture of Gaussian emissions per state
- Implements Rabiner Section VIII (Eq 49-54) formulas
- Baum-Welch reestimation for mixture weights, means, and covariances
- 7 new tests for MixtureGaussianHMM

Fixes #31