### PR TITLE
Add Gaussian ellipses visualization to continuous HMM notebook

### DIFF
--- a/notebooks/06-continuous-hmm.ipynb
+++ b/notebooks/06-continuous-hmm.ipynb
@@ -24,10 +24,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from hmm.continuous import GaussianHMM\n",
-    "from hmm.algorithms import forward, backward, viterbi, baum_welch"
+    "import numpy as np\n",
+    "\n",
+    "from hmm.algorithms import baum_welch, forward, viterbi\n",
+    "from hmm.continuous import GaussianHMM"
    ]
   },
   {
@@ -128,6 +129,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Visualizing Gaussian Emissions\n",
+    "\n",
+    "We can visualize the Gaussian emission distributions as ellipses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hmm.viz import plot_gaussian_ellipses\n",
+    "\n",
+    "# Visualize the Gaussian emissions as ellipses\n",
+    "fig = plot_gaussian_ellipses(hmm.means, hmm.covars, n_std=2)\n",
+    "plt.title('Gaussian Emission Ellipses')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Forward Algorithm\n",
     "\n",
     "The forward algorithm computes the probability of observing a sequence given the model."
@@ -205,8 +229,24 @@
     "print(\"Initial means:\", hmm_train.means.flatten())\n",
     "print(\"Initial covariances:\", hmm_train.covars.flatten())\n",
     "\n",
+    "# Visualize initial Gaussians\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 4))\n",
+    "\n",
+    "# Before training\n",
+    "plot_gaussian_ellipses(hmm_train.means, hmm_train.covars, ax=axes[0], n_std=2)\n",
+    "axes[0].set_title('Before Training')\n",
+    "axes[0].set_xlim(-5, 15)\n",
+    "\n",
     "# Train the model\n",
-    "trained_hmm = baum_welch(hmm_train, [observations], epochs=50, verbose=True)\n",
+    "trained_hmm = baum_welch(hmm_train, [observations], epochs=50, verbose=False)\n",
+    "\n",
+    "# After training\n",
+    "plot_gaussian_ellipses(trained_hmm.means, trained_hmm.covars, ax=axes[1], n_std=2)\n",
+    "axes[1].set_title('After Training')\n",
+    "axes[1].set_xlim(-5, 15)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
     "\n",
     "print(\"\\nTrained means:\", trained_hmm.means.flatten())\n",
     "print(\"Trained covariances:\", trained_hmm.covars.flatten())"
@@ -307,7 +347,8 @@
     "for _ in range(50):\n",
     "    state = np.random.choice(2, p=mix_hmm.Pi)\n",
     "    mix_idx = np.random.choice(2, p=mix_hmm.weights[state])\n",
-    "    obs = mix_hmm.means[state, mix_idx, 0] + np.sqrt(mix_hmm.covars[state, mix_idx, 0, 0]) * np.random.randn()\n",
+    "    obs = (mix_hmm.means[state, mix_idx, 0] +\n",
+    "            np.sqrt(mix_hmm.covars[state, mix_idx, 0, 0]) * np.random.randn())\n",
     "    train_obs.append([obs])\n",
     "train_obs = np.array(train_obs)\n",
     "\n",


### PR DESCRIPTION
## Summary

- Add visualization of Gaussian emission ellipses using `hmm.viz.plot_gaussian_ellipses`
- Show ellipses when introducing GaussianHMM
- Visualize before/after training during Baum-Welch section

Fixes #35