### PR TITLE
Add covariance regularization to prevent matrix singularity (Issue #41)

### DIFF
--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -190,6 +190,7 @@ def baum_welch(
     graph: bool = False,
     fname: str = "ll.eps",
     verbose: bool = False,
+    reg_covar: float | None = None,
 ) -> "HMM":
     """EM algorithm to update Pi, A, and B for the HMM.
 
@@ -210,10 +211,14 @@ def baum_welch(
         graph: flag to plot log-likelihoods (default: False)
         fname: file name to save plot figure (default: "ll.eps")
         verbose: flag to print training progress (default: False)
+        reg_covar: covariance regularization constant (default: from hmm.reg_covar or 1e-6)
 
     Returns:
         Trained HMM model
     """
+    # Use reg_covar from hmm if not provided
+    if reg_covar is None:
+        reg_covar = getattr(hmm, "reg_covar", 1e-6)
     # Check if this is a GaussianHMM (doesn't have M attribute)
     is_gaussian = not hasattr(hmm, "M")
 
@@ -379,21 +384,25 @@ def baum_welch(
                             if expect_mix_sum[j, k] > 0:
                                 hmm.means[j, k] = expect_obs_sum[j, k] / expect_mix_sum[j, k]
 
-                    # Update covariances (Rabiner Eq. 54)
+                    # Update covariances (Rabiner Eq. 54) with regularization
                     for j in range(hmm.N):
                         for k in range(hmm.n_mixtures):
                             if expect_mix_sum[j, k] > 0:
-                                hmm.covars[j, k] = expect_obs_cov[j, k] / expect_mix_sum[j, k]
+                                hmm.covars[j, k] = (expect_obs_cov[j, k] / expect_mix_sum[j, k]) + (
+                                    reg_covar * np.eye(hmm.n_features)
+                                )
                 else:
                     # Single Gaussian case - Update means (Rabiner Eq. 53)
                     for j in range(hmm.N):
                         if expect_si_all[j] > 0:
                             hmm.means[j] = expect_obs_sum[j] / expect_si_all[j]
 
-                    # Update covariances (Rabiner Eq. 54)
+                    # Update covariances (Rabiner Eq. 54) with regularization
                     for j in range(hmm.N):
                         if expect_si_all[j] > 0:
-                            hmm.covars[j] = expect_obs_cov[j] / expect_si_all[j]
+                            hmm.covars[j] = (expect_obs_cov[j] / expect_si_all[j]) + (
+                                reg_covar * np.eye(hmm.n_features)
+                            )
             else:
                 # Discrete B matrix update
                 for i in range(hmm.N):

--- a/src/hmm/continuous.py
+++ b/src/hmm/continuous.py
@@ -29,6 +29,7 @@ class GaussianHMM:
         means: npt.NDArray | None = None,
         covars: npt.NDArray | None = None,
         Labels: list[int] | None = None,
+        reg_covar: float = 1e-6,
     ) -> None:
         """Initialize a Continuous HMM with Gaussian emissions.
 
@@ -40,9 +41,11 @@ class GaussianHMM:
             means: Mean vectors (N x n_features)
             covars: Covariance matrices (N x n_features x n_features)
             Labels: State labels
+            reg_covar: Regularization constant added to covariance matrices to prevent singularity
         """
         self.N = n_states
         self.n_features = n_features
+        self.reg_covar = reg_covar
 
         # Initialize Transition Matrix A
         if A is not None:
@@ -96,13 +99,16 @@ class GaussianHMM:
         d = self.n_features
         diff = np.asarray(obs) - np.asarray(mu)
 
+        # Add regularization to prevent singular covariance
+        reg_cov = cov + (self.reg_covar * np.eye(d))
+
         if d == 1:
             diff_scalar = float(np.squeeze(diff))
-            var = float(np.squeeze(cov))
+            var = float(np.squeeze(reg_cov))
             return float(np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(2 * np.pi * var))
         else:
-            cov_inv = np.linalg.inv(cov)
-            det_cov = np.linalg.det(cov)
+            cov_inv = np.linalg.inv(reg_cov)
+            det_cov = np.linalg.det(reg_cov)
             exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
             return float(np.exp(exponent) / np.sqrt(((2 * np.pi) ** d) * det_cov))
 
@@ -158,6 +164,7 @@ class MixtureGaussianHMM:
         means: npt.NDArray | None = None,
         covars: npt.NDArray | None = None,
         Labels: list[int] | None = None,
+        reg_covar: float = 1e-6,
     ) -> None:
         """Initialize a Mixture Gaussian HMM.
 
@@ -171,10 +178,12 @@ class MixtureGaussianHMM:
             means: Mean vectors (N x n_mixtures x n_features)
             covars: Covariance matrices (N x n_mixtures x n_features x n_features)
             Labels: State labels
+            reg_covar: Regularization constant added to covariance matrices to prevent singularity
         """
         self.N = n_states
         self.n_features = n_features
         self.n_mixtures = n_mixtures
+        self.reg_covar = reg_covar
 
         if A is not None:
             self.A = np.array(A, dtype=float)
@@ -234,13 +243,16 @@ class MixtureGaussianHMM:
         d = self.n_features
         diff = np.asarray(obs) - np.asarray(mean)
 
+        # Add regularization to prevent singular covariance
+        reg_cov = cov + (self.reg_covar * np.eye(d))
+
         if d == 1:
             diff_scalar = float(np.squeeze(diff))
-            var = float(np.squeeze(cov))
+            var = float(np.squeeze(reg_cov))
             return float(np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(2 * np.pi * var))
         else:
-            cov_inv = np.linalg.inv(cov)
-            det_cov = np.linalg.det(cov)
+            cov_inv = np.linalg.inv(reg_cov)
+            det_cov = np.linalg.det(reg_cov)
             exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
             return float(np.exp(exponent) / np.sqrt(((2 * np.pi) ** d) * det_cov))
 


### PR DESCRIPTION
## Summary
- Adds `reg_covar` parameter (default: 1e-6) to GaussianHMM and MixtureGaussianHMM
- Applies regularization during M-step covariance updates in baum_welch
- Adds regularization to emission_prob and _gaussian_pdf calculations to prevent crashes

## Changes
- `src/hmm/continuous.py`: Added reg_covar param to __init__ methods, applied in emission calculations
- `src/hmm/algorithms.py`: Added reg_covar param to baum_welch, applied during M-step updates

## Testing
- All 57 existing tests pass
- Verified fix prevents crash with collapsed (zero) covariance matrices

## Fixes Issue #41