### PR TITLE
Add backward scaling warning for long sequences (Issue #42)

### DIFF
--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -1,5 +1,6 @@
 """HMM algorithms: forward, backward, viterbi, baum_welch."""
 
+import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -109,6 +110,15 @@ def backward(
         Beta: backward variable matrix (N x T)
     """
     T = len(obs)
+
+    # Warn if using unscaled backward for long sequences
+    if c is None and T > 50:
+        warnings.warn(
+            f"backward: No scaling coefficients provided for long sequence (T={T}). "
+            "Unscaled backward values may underflow to zero. "
+            "Consider using scaling=True in forward and passing c to backward.",
+            RuntimeWarning,
+        )
 
     beta = np.zeros([hmm.N, T], dtype=float)
     beta[:, T - 1] = 1.0


### PR DESCRIPTION
## Summary
- Adds RuntimeWarning when backward() is called without scaling coefficients for sequences longer than 50 time steps
- Recommends using scaling=True in forward and passing c to backward

## Changes
- `src/hmm/algorithms.py`: Added warning in backward function

## Testing
- All 57 existing tests pass
- Verified warning is triggered for long sequences without scaling

## Fixes Issue #42