### PR TITLE
DRY up Gaussian PDF calculations (Issue #44)

### DIFF
--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -10,6 +10,8 @@ import numpy as np
 import numpy.typing as npt
 from einops import rearrange
 
+from hmm.continuous import gaussian_pdf
+
 if TYPE_CHECKING:
     from hmm.continuous import GaussianHMM, MixtureGaussianHMM
     from hmm.hmm import HMM
@@ -333,30 +335,17 @@ def baum_welch(
                                     sigma_jk = hmm.covars[j, k]
 
                                     # Gaussian PDF for this mixture component
-                                    diff = np.asarray(obs_t) - np.asarray(mu_jk)
-                                    if hmm.n_features == 1:
-                                        diff_scalar = float(diff.flatten()[0])
-                                        sigma_jk_arr = np.asarray(sigma_jk).flatten()
-                                        var = float(sigma_jk_arr[0])
-                                        pdf = np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(
-                                            2 * np.pi * var
-                                        )
+                                    pdf = gaussian_pdf(obs_t, mu_jk, sigma_jk, reg_covar)
+                                    if b_j[j] > 0:
+                                        gamma_jk = gamma[j, t] * c_jk * pdf / b_j[j]
                                     else:
-                                        cov_inv = np.linalg.inv(sigma_jk)
-                                        det_cov = np.linalg.det(sigma_jk)
-                                        exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
-                                        pdf = np.exp(exponent) / np.sqrt(
-                                            ((2 * np.pi) ** hmm.n_features) * det_cov
-                                        )
-                                if b_j[j] > 0:
-                                    gamma_jk = gamma[j, t] * c_jk * pdf / b_j[j]
-                                else:
-                                    gamma_jk = 0.0
+                                        gamma_jk = 0.0
 
-                                expect_mix_sum[j, k] += gamma_jk
-                                expect_obs_sum[j, k] += gamma_jk * obs_t
-                                diff_outer = np.outer(diff, diff)
-                                expect_obs_cov[j, k] += gamma_jk * diff_outer
+                                    expect_mix_sum[j, k] += gamma_jk
+                                    expect_obs_sum[j, k] += gamma_jk * obs_t
+                                    diff = np.asarray(obs_t) - np.asarray(mu_jk)
+                                    diff_outer = np.outer(diff, diff)
+                                    expect_obs_cov[j, k] += gamma_jk * diff_outer
                         else:
                             # Single Gaussian case
                             for j in range(hmm.N):

--- a/src/hmm/continuous.py
+++ b/src/hmm/continuous.py
@@ -5,6 +5,40 @@ import numpy.typing as npt
 from numpy import random as rand
 
 
+def gaussian_pdf(
+    obs: npt.ArrayLike,
+    mean: npt.NDArray,
+    cov: npt.NDArray,
+    reg_covar: float = 1e-6,
+) -> float:
+    """Calculate multivariate Gaussian probability density.
+
+    Args:
+        obs: Observation vector (n_features,)
+        mean: Mean vector (n_features,)
+        cov: Covariance matrix (n_features x n_features)
+        reg_covar: Regularization constant to prevent singular covariance
+
+    Returns:
+        Probability density at obs
+    """
+    obs_arr = np.asarray(obs)
+    d = obs_arr.shape[0] if obs_arr.ndim > 0 else 1
+    diff = obs_arr - np.asarray(mean)
+
+    reg_cov = cov + (reg_covar * np.eye(d))
+
+    if d == 1:
+        diff_scalar = float(np.squeeze(diff))
+        var = float(np.squeeze(reg_cov))
+        return float(np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(2 * np.pi * var))
+    else:
+        cov_inv = np.linalg.inv(reg_cov)
+        det_cov = np.linalg.det(reg_cov)
+        exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
+        return float(np.exp(exponent) / np.sqrt(((2 * np.pi) ** d) * det_cov))
+
+
 class GaussianHMM:
     """
     Continuous Hidden Markov Model with single multivariate Gaussian emissions per state.
@@ -82,7 +116,7 @@ class GaussianHMM:
         else:
             self.Labels = list(range(self.N))
 
-    def emission_prob(self, state: int, obs: int | npt.NDArray) -> float:
+    def emission_prob(self, state: int, obs: npt.ArrayLike) -> float:
         """Calculate b_j(O) = N(O, mu_j, U_j).
 
         Returns the probability density of observation vector 'obs' given 'state'.
@@ -94,23 +128,7 @@ class GaussianHMM:
         Returns:
             Probability density at obs
         """
-        mu = self.means[state]
-        cov = self.covars[state]
-        d = self.n_features
-        diff = np.asarray(obs) - np.asarray(mu)
-
-        # Add regularization to prevent singular covariance
-        reg_cov = cov + (self.reg_covar * np.eye(d))
-
-        if d == 1:
-            diff_scalar = float(np.squeeze(diff))
-            var = float(np.squeeze(reg_cov))
-            return float(np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(2 * np.pi * var))
-        else:
-            cov_inv = np.linalg.inv(reg_cov)
-            det_cov = np.linalg.det(reg_cov)
-            exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
-            return float(np.exp(exponent) / np.sqrt(((2 * np.pi) ** d) * det_cov))
+        return gaussian_pdf(obs, self.means[state], self.covars[state], self.reg_covar)
 
     def get_emission_probs(self, obs_t: int | npt.NDArray) -> npt.NDArray:
         """Returns emission probabilities for all states given observation obs_t.
@@ -229,7 +247,7 @@ class MixtureGaussianHMM:
         else:
             self.Labels = list(range(self.N))
 
-    def _gaussian_pdf(self, mean: npt.NDArray, cov: npt.NDArray, obs: npt.NDArray) -> float:
+    def _gaussian_pdf(self, mean: npt.NDArray, cov: npt.NDArray, obs: npt.ArrayLike) -> float:
         """Calculate Gaussian PDF for multivariate case.
 
         Args:
@@ -240,23 +258,9 @@ class MixtureGaussianHMM:
         Returns:
             Probability density
         """
-        d = self.n_features
-        diff = np.asarray(obs) - np.asarray(mean)
+        return gaussian_pdf(obs, mean, cov, self.reg_covar)
 
-        # Add regularization to prevent singular covariance
-        reg_cov = cov + (self.reg_covar * np.eye(d))
-
-        if d == 1:
-            diff_scalar = float(np.squeeze(diff))
-            var = float(np.squeeze(reg_cov))
-            return float(np.exp(-0.5 * (diff_scalar**2) / var) / np.sqrt(2 * np.pi * var))
-        else:
-            cov_inv = np.linalg.inv(reg_cov)
-            det_cov = np.linalg.det(reg_cov)
-            exponent = -0.5 * np.dot(np.dot(diff.T, cov_inv), diff)
-            return float(np.exp(exponent) / np.sqrt(((2 * np.pi) ** d) * det_cov))
-
-    def emission_prob(self, state: int, obs: int | npt.NDArray) -> float:
+    def emission_prob(self, state: int, obs: npt.ArrayLike) -> float:
         """Calculate b_j(O) = sum_k c_jk * N(O, mu_jk, U_jk).
 
         Returns the probability density of observation vector 'obs' given 'state'


### PR DESCRIPTION
## Summary
- Add standalone `gaussian_pdf()` utility function in continuous.py
- Refactor `GaussianHMM.emission_prob` to use `gaussian_pdf()`
- Refactor `MixtureGaussianHMM._gaussian_pdf` to use `gaussian_pdf()`
- Refactor `baum_welch` to use `gaussian_pdf()`

## Changes
- `src/hmm/continuous.py`: Added gaussian_pdf utility, refactored methods
- `src/hmm/algorithms.py`: Updated baum_welch to use utility function

## Benefits
- Single source of truth for Gaussian PDF calculations
- Easier to maintain and update
- Can add optimizations in one place

## Testing
- All 57 existing tests pass
- ruff checks pass

## Fixes Issue #44