### PR TITLE
Python 2 to 3 modernization fixes (Issue #45)

### DIFF
--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -236,8 +237,6 @@ def baum_welch(
     # Check if this is a GaussianHMM (doesn't have M attribute)
     is_gaussian = not hasattr(hmm, "M")
 
-    import copy
-
     LLs: list[float] = []
     val_LLs: list[float] = []
     best_A = copy.deepcopy(hmm.A)
@@ -412,7 +411,7 @@ def baum_welch(
 
                 hmm.B = expect_si_vk_all
 
-                for i in hmm.F.keys():
+                for i in hmm.F:
                     hmm.B[i, :] = hmm.F[i]
 
         LLs.append(LL_epoch)

--- a/src/hmm/continuous.py
+++ b/src/hmm/continuous.py
@@ -96,7 +96,7 @@ class GaussianHMM:
             self.Pi = np.array(Pi, dtype=float)
             assert len(self.Pi) == self.N
         else:
-            self.Pi = np.array(1.0 / self.N).repeat(self.N)
+            self.Pi = np.array(1 / self.N).repeat(self.N)
 
         # Initialize Continuous Emission Parameters (means and covariances)
         if means is not None:
@@ -216,7 +216,7 @@ class MixtureGaussianHMM:
             self.Pi = np.array(Pi, dtype=float)
             assert len(self.Pi) == self.N
         else:
-            self.Pi = np.array(1.0 / self.N).repeat(self.N)
+            self.Pi = np.array(1 / self.N).repeat(self.N)
 
         if weights is not None:
             self.weights = np.array(weights, dtype=float)

--- a/src/hmm/hmm.py
+++ b/src/hmm/hmm.py
@@ -137,7 +137,7 @@ class HMM:
 
         self.V = list(V)
         self.M = len(self.V)
-        self.symbol_map = dict(zip(self.V, range(len(self.V))))
+        self.symbol_map: dict[int, int] = {v: i for i, v in enumerate(self.V)}
 
         if A is not None:
             self.A = np.array(A, dtype=float)
@@ -157,7 +157,7 @@ class HMM:
 
             if F is not None:
                 self.F = dict(F)
-                for i in self.F.keys():
+                for i in self.F:
                     self.B[i, :] = self.F[i]
             else:
                 self.F = {}
@@ -167,7 +167,7 @@ class HMM:
 
             if F is not None:
                 self.F = dict(F)
-                for i in self.F.keys():
+                for i in self.F:
                     self.B[i, :] = self.F[i]
             else:
                 self.F = {}
@@ -176,7 +176,7 @@ class HMM:
             self.Pi = np.array(Pi, dtype=float)
             assert len(self.Pi) == self.N
         else:
-            self.Pi = np.array(1.0 / self.N).repeat(self.N)
+            self.Pi = np.array(1 / self.N).repeat(self.N)
 
         if Labels is not None:
             self.Labels = list(Labels)


### PR DESCRIPTION
## Summary
- Fix integer division: `1.0 / N` -> `1 / N` (3 locations)
- Fix dict iteration: `.keys()` removed
- Fix dict creation: `dict(zip(...))` -> dict comprehension
- Move inline import `copy` to top of file

## Changes
- `src/hmm/hmm.py`: Fixed integer division, dict iteration, dict comprehension
- `src/hmm/algorithms.py`: Fixed dict iteration, moved import
- `src/hmm/continuous.py`: Fixed integer division

## Testing
- All 57 existing tests pass
- ruff checks pass

## Fixes Issue #45