### PR TITLE
fix: critical bugs in LOG mode and M-step covariance

### DIFF
--- a/src/hmm/__init__.py
+++ b/src/hmm/__init__.py
@@ -1,8 +1,7 @@
 # HMMPY - Hidden Markov Models in Python
 # Based on Rabiner tutorial
 
-from hmm.algorithms import backward, baum_welch, forward, viterbi
-from hmm.algorithms import ComputeMode
+from hmm.algorithms import ComputeMode, backward, baum_welch, forward, viterbi
 from hmm.continuous import GaussianHMM
 from hmm.hmm import HMM, HMMClassifier
 

--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -14,6 +14,8 @@ from scipy.special import logsumexp
 
 from hmm.base import HMMProtocol
 
+EPSILON = np.finfo(float).tiny
+
 
 class ComputeMode(Enum):
     """Computation mode for HMM algorithms."""
@@ -76,19 +78,18 @@ def forward(
         For "unscaled" mode: (prob_Obs, Alpha, None)
     """
     T = len(obs)
-    tiny = np.finfo(float).tiny
 
     if mode == ComputeMode.LOG:
-        log_Pi = np.log(np.maximum(hmm.Pi, tiny))
-        log_A = np.log(np.maximum(hmm.A, tiny))
+        log_Pi = np.log(np.maximum(hmm.Pi, EPSILON))
+        log_A = np.log(np.maximum(hmm.A, EPSILON))
 
         log_alpha = np.zeros([hmm.N, T], dtype=float)
 
-        log_alpha[:, 0] = log_Pi + np.log(np.maximum(hmm.get_emission_probs(obs[0]), tiny))
+        log_alpha[:, 0] = log_Pi + np.log(np.maximum(hmm.get_emission_probs(obs[0]), EPSILON))
 
         for t in range(1, T):
             log_alpha[:, t] = logsumexp(log_alpha[:, t - 1, None] + log_A, axis=0) + np.log(
-                np.maximum(hmm.get_emission_probs(obs[t]), tiny)
+                np.maximum(hmm.get_emission_probs(obs[t]), EPSILON)
             )
 
         log_prob_Obs = logsumexp(log_alpha[:, T - 1])
@@ -103,14 +104,14 @@ def forward(
     alpha[:, 0] = hmm.Pi * hmm.get_emission_probs(obs[0])
 
     if mode == ComputeMode.SCALED and c is not None:
-        c[0] = 1.0 / np.maximum(np.sum(alpha[:, 0]), tiny)
+        c[0] = 1.0 / np.maximum(np.sum(alpha[:, 0]), EPSILON)
         alpha[:, 0] = c[0] * alpha[:, 0]
 
     for t in range(1, T):
         alpha[:, t] = np.dot(alpha[:, t - 1], hmm.A) * hmm.get_emission_probs(obs[t])
 
         if mode == ComputeMode.SCALED and c is not None:
-            c[t] = 1.0 / np.maximum(np.sum(alpha[:, t]), tiny)
+            c[t] = 1.0 / np.maximum(np.sum(alpha[:, t]), EPSILON)
             alpha[:, t] = alpha[:, t] * c[t]
 
     if mode == ComputeMode.SCALED and c is not None:
@@ -141,10 +142,9 @@ def backward(
         Beta: backward variable matrix (N x T)
     """
     T = len(obs)
-    tiny = np.finfo(float).tiny
 
     if mode == ComputeMode.LOG:
-        log_A = np.log(np.maximum(hmm.A, tiny))
+        log_A = np.log(np.maximum(hmm.A, EPSILON))
 
         log_beta = np.zeros([hmm.N, T], dtype=float)
         log_beta[:, T - 1] = 0.0
@@ -152,12 +152,12 @@ def backward(
         for t in reversed(range(T - 1)):
             log_beta[:, t] = logsumexp(
                 log_A
-                + log_beta[:, t + 1, None]
-                + np.log(np.maximum(hmm.get_emission_probs(obs[t + 1]), tiny)),
-                axis=0,
+                + log_beta[:, t + 1]
+                + np.log(np.maximum(hmm.get_emission_probs(obs[t + 1]), EPSILON)),
+                axis=1,
             )
 
-        return np.exp(log_beta)
+        return log_beta
 
     c: npt.NDArray | None = scaling_coeffs
     if c is None:
@@ -177,7 +177,7 @@ def backward(
         beta[:, t] = np.dot(hmm.A, (hmm.get_emission_probs(obs[t + 1]) * beta[:, t + 1]))
 
         if mode == ComputeMode.SCALED and c is not None and scaling_coeffs is None:
-            c[t] = 1.0 / np.maximum(np.sum(beta[:, t]), tiny)
+            c[t] = 1.0 / np.maximum(np.sum(beta[:, t]), EPSILON)
             beta[:, t] = beta[:, t] * c[t]
         elif mode == ComputeMode.SCALED and c is not None:
             beta[:, t] = beta[:, t] * c[t]
@@ -208,11 +208,10 @@ def viterbi(
     T = len(obs)
 
     delta = np.zeros([hmm.N, T], dtype=float)
-    tiny = np.finfo(float).tiny
 
     if mode in (ComputeMode.SCALED, ComputeMode.LOG):
-        delta[:, 0] = np.log(np.maximum(hmm.Pi, tiny)) + np.log(
-            np.maximum(hmm.get_emission_probs(obs[0]), tiny)
+        delta[:, 0] = np.log(np.maximum(hmm.Pi, EPSILON)) + np.log(
+            np.maximum(hmm.get_emission_probs(obs[0]), EPSILON)
         )
     else:
         delta[:, 0] = hmm.Pi * hmm.get_emission_probs(obs[0])
@@ -221,8 +220,8 @@ def viterbi(
 
     if mode in (ComputeMode.SCALED, ComputeMode.LOG):
         for t in range(1, T):
-            nus = rearrange(delta[:, t - 1], "n -> n 1") + np.log(np.maximum(hmm.A, tiny))
-            delta[:, t] = nus.max(0) + np.log(np.maximum(hmm.get_emission_probs(obs[t]), tiny))
+            nus = rearrange(delta[:, t - 1], "n -> n 1") + np.log(np.maximum(hmm.A, EPSILON))
+            delta[:, t] = nus.max(0) + np.log(np.maximum(hmm.get_emission_probs(obs[t]), EPSILON))
             psi[:, t] = nus.argmax(0)
     else:
         for t in range(1, T):
@@ -271,7 +270,7 @@ def baum_welch(
     Returns:
         Trained HMM model
     """
-    tiny = np.finfo(float).tiny
+    TOL = 1e-4
 
     LLs: list[float] = []
     val_LLs: list[float] = []
@@ -294,21 +293,36 @@ def baum_welch(
 
             LL_epoch += log_prob_obs
 
-            gamma_raw = alpha * beta
-            gamma = gamma_raw / np.maximum(gamma_raw.sum(0), tiny)
+            if mode == ComputeMode.LOG:
+                log_gamma_raw = alpha + beta
+                gamma = np.exp(log_gamma_raw - logsumexp(log_gamma_raw, axis=0))
+            else:
+                gamma_raw = alpha * beta
+                gamma = gamma_raw / np.maximum(gamma_raw.sum(0), EPSILON)
             gammas.append(gamma)
 
             B_next = np.column_stack([hmm.get_emission_probs(o) for o in obs_list[1:]])
 
-            xi = np.einsum(
-                "it, ij, jt, jt -> ijt",
-                alpha[:, :-1],
-                hmm.A,
-                B_next,
-                beta[:, 1:],
-            )
-
-            xi /= np.maximum(xi.sum(axis=(0, 1), keepdims=True), tiny)
+            if mode == ComputeMode.LOG:
+                log_B = np.log(np.maximum(B_next, EPSILON))
+                log_alpha = alpha[:, :-1]
+                log_beta = beta[:, 1:]
+                log_xi = (
+                    rearrange(log_alpha, "n t -> t n 1")
+                    + np.log(hmm.A)
+                    + log_B
+                    + rearrange(log_beta, "n t -> t 1 n")
+                )
+                xi = np.exp(log_xi - logsumexp(log_xi, axis=(1, 2), keepdims=True))
+            else:
+                xi = np.einsum(
+                    "it, ij, jt, jt -> ijt",
+                    alpha[:, :-1],
+                    hmm.A,
+                    B_next,
+                    beta[:, 1:],
+                )
+                xi /= np.maximum(xi.sum(axis=(0, 1), keepdims=True), EPSILON)
 
             xis.append(xi)
 
@@ -323,9 +337,9 @@ def baum_welch(
 
         LLs.append(LL_epoch)
 
-        if epoch > 1 and LLs[epoch - 1] == LL_epoch:
+        if epoch > 1 and abs(LLs[epoch] - LLs[epoch - 1]) < TOL:
             if verbose:
-                print("Log-likelihoods have plateaued--terminating training")
+                print("Log-likelihoods have converged.")
             break
 
         if val_set is not None:

--- a/src/hmm/continuous.py
+++ b/src/hmm/continuous.py
@@ -89,7 +89,7 @@ class GaussianHMM:
             assert np.shape(self.A) == (self.N, self.N)
         else:
             raw_A = rand.uniform(size=self.N * self.N).reshape((self.N, self.N))
-            self.A = (raw_A.T / raw_A.T.sum(0)).T
+            self.A = raw_A / raw_A.sum(axis=1, keepdims=True)
             if n_states == 1:
                 self.A = self.A.reshape((1, 1))
 
@@ -176,8 +176,7 @@ class GaussianHMM:
                     obs_t = np.asarray(obs[t])
                     for j in range(self.N):
                         expect_obs_sum[j] += gamma[j, t] * obs_t
-                        diff = obs_t - self.means[j]
-                        expect_obs_cov[j] += gamma[j, t] * np.outer(diff, diff)
+                        expect_obs_cov[j] += gamma[j, t] * np.outer(obs_t, obs_t)
 
         if update_pi:
             self.Pi = expect_si_t0_all / np.sum(expect_si_t0_all)
@@ -191,8 +190,10 @@ class GaussianHMM:
             for j in range(self.N):
                 if expect_si_all[j] > 0:
                     self.means[j] = expect_obs_sum[j] / expect_si_all[j]
-                    self.covars[j] = (expect_obs_cov[j] / expect_si_all[j]) + (
-                        self.reg_covar * np.eye(self.n_features)
+                    self.covars[j] = (
+                        (expect_obs_cov[j] / expect_si_all[j])
+                        - np.outer(self.means[j], self.means[j])
+                        + (self.reg_covar * np.eye(self.n_features))
                     )
 
     def __repr__(self) -> str:
@@ -259,7 +260,7 @@ class MixtureGaussianHMM:
             assert np.shape(self.A) == (self.N, self.N)
         else:
             raw_A = rand.uniform(size=self.N * self.N).reshape((self.N, self.N))
-            self.A = (raw_A.T / raw_A.T.sum(0)).T
+            self.A = raw_A / raw_A.sum(axis=1, keepdims=True)
             if n_states == 1:
                 self.A = self.A.reshape((1, 1))
 
@@ -390,8 +391,7 @@ class MixtureGaussianHMM:
                                 gamma_jk = 0.0
                             expect_mix_sum[j, k] += gamma_jk
                             expect_obs_sum[j, k] += gamma_jk * obs_t
-                            diff = obs_t - mu_jk
-                            expect_obs_cov[j, k] += gamma_jk * np.outer(diff, diff)
+                            expect_obs_cov[j, k] += gamma_jk * np.outer(obs_t, obs_t)
 
         if update_pi:
             self.Pi = expect_si_t0_all / np.sum(expect_si_t0_all)
@@ -410,8 +410,10 @@ class MixtureGaussianHMM:
                 for k in range(self.n_mixtures):
                     if expect_mix_sum[j, k] > 0:
                         self.means[j, k] = expect_obs_sum[j, k] / expect_mix_sum[j, k]
-                        self.covars[j, k] = (expect_obs_cov[j, k] / expect_mix_sum[j, k]) + (
-                            self.reg_covar * np.eye(self.n_features)
+                        self.covars[j, k] = (
+                            (expect_obs_cov[j, k] / expect_mix_sum[j, k])
+                            - np.outer(self.means[j, k], self.means[j, k])
+                            + (self.reg_covar * np.eye(self.n_features))
                         )
 
     def __repr__(self) -> str:

--- a/src/hmm/hmm.py
+++ b/src/hmm/hmm.py
@@ -144,7 +144,7 @@ class HMM:
             assert np.shape(self.A) == (self.N, self.N)
         else:
             raw_A = rand.uniform(size=self.N * self.N).reshape((self.N, self.N))
-            self.A = (raw_A.T / raw_A.T.sum(0)).T
+            self.A = raw_A / raw_A.sum(axis=1, keepdims=True)
             if n_states == 1:
                 self.A = self.A.reshape((1, 1))
 
@@ -163,7 +163,7 @@ class HMM:
                 self.F = {}
         else:
             B_raw = rand.uniform(0, 1, self.N * self.M).reshape((self.N, self.M))
-            self.B = (B_raw.T / B_raw.T.sum(0)).T
+            self.B = B_raw / B_raw.sum(axis=1, keepdims=True)
 
             if F is not None:
                 self.F = dict(F)
@@ -215,7 +215,7 @@ class HMM:
         expect_si_vk_all = np.zeros([self.N, self.M], dtype=float)
 
         for obs, gamma, xi in zip(obs_seqs, gammas, xis):
-            obs_symbols = [self.symbol_map[o] for o in obs]
+            obs_symbols = np.array([self.symbol_map[o] for o in obs])
             T = len(obs)
 
             expect_si_t0_all += gamma[:, 0]
@@ -225,8 +225,8 @@ class HMM:
             if update_b:
                 B_bar = np.zeros([self.N, self.M], dtype=float)
                 for k in range(self.M):
-                    which = np.array([self.V[k] == x for x in obs_symbols])
-                    B_bar[:, k] = gamma.T[which, :].sum(0)
+                    which = obs_symbols == k
+                    B_bar[:, k] = gamma[:, which].sum(1)
                 expect_si_vk_all += B_bar
 
         if update_pi:
@@ -238,12 +238,10 @@ class HMM:
                     self.A[i, :] = expect_si_sj_all_TM1[i, :] / expect_si_all_TM1[i]
 
         if update_b:
-            if gamma is not None:
-                for i in range(self.N):
-                    if gamma.sum() > 0:
-                        row_sum = expect_si_vk_all[i, :].sum()
-                        if row_sum > 0:
-                            expect_si_vk_all[i, :] = expect_si_vk_all[i, :] / row_sum
+            for i in range(self.N):
+                row_sum = expect_si_vk_all[i, :].sum()
+                if row_sum > 0:
+                    expect_si_vk_all[i, :] = expect_si_vk_all[i, :] / row_sum
 
             self.B = expect_si_vk_all
 


### PR DESCRIPTION
## Summary
- Fix `backward()` to return `log_beta` instead of `exp(log_beta)` in LOG mode
- Fix broadcasting axis in backward log mode (axis=1 instead of axis=0)
- Fix `baum_welch` gamma calculation for LOG mode using logsumexp
- Fix M-step covariance to use identity: Σ = E[XX^T] - μμ^T (Rabiner Eq. 54)
- Fix state leakage in discrete M-step normalization
- Refactor matrix normalization to use `keepdims=True`
- Fix list comprehension in discrete m_step (vectorized equality)
- Add tolerance (1e-4) to early stopping
- Add EPSILON constant at module level

## Changes
- `src/hmm/algorithms.py`: LOG mode fixes, EPSILON constant, early stopping tolerance
- `src/hmm/continuous.py`: Covariance identity fix, matrix normalization refactor
- `src/hmm/hmm.py`: State leakage fix, normalization refactor, list comprehension fix

All 57 tests pass.