### PR TITLE
Fix LOG Baum-Welch and classifier regressions; harden docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ uv pip install -e ".[all]"
 ## Quick Start
 
 ```python
-from hmm import HMM, forward, viterbi, baum_welch
+from hmm import HMM, baum_welch, forward, viterbi
+from hmm.algorithms import ComputeMode
 
 # Create an HMM with 2 states
 A = [[0.95, 0.05], [0.05, 0.95]]  # Transition matrix
@@ -44,10 +45,10 @@ V = [1, 2, 3, 4, 5, 6]            # Observation symbols
 hmm = HMM(n_states=2, A=A, B=B, V=V)
 
 # Run forward algorithm
-log_prob, alpha, c = forward(hmm, [1, 2, 1, 6, 6], scaling=True)
+log_prob, alpha, c = forward(hmm, [1, 2, 1, 6, 6], mode=ComputeMode.SCALED)
 
 # Decode most likely state sequence
-states, delta, psi = viterbi(hmm, [1, 2, 1, 6, 6], scaling=True)
+states, delta, psi = viterbi(hmm, [1, 2, 1, 6, 6], mode=ComputeMode.LOG)
 
 # Train on observation sequences
 trained_hmm = baum_welch(hmm, [[1, 2, 3], [6, 5, 4]], epochs=20)
@@ -58,7 +59,7 @@ trained_hmm = baum_welch(hmm, [[1, 2, 3], [6, 5, 4]], epochs=20)
 | Algorithm | Description |
 |-----------|-------------|
 | **Forward** | Calculate P(Obs|HMM) using forward variables |
-| **Backward** | Calculate backward probabilities forposterior decoding |
+| **Backward** | Calculate backward probabilities for posterior decoding |
 | **Viterbi** | Find most likely state sequence |
 | **Baum-Welch** | Train HMM parameters using EM |
 | **HMMClassifier** | Binary classification using two HMMs |

--- a/_config.yml
+++ b/_config.yml
@@ -2,9 +2,26 @@
 
 title: HMMPY
 author: Mike Hamilton
-copyright: 2026
+copyright: "2026"
 
-exclude_patterns: [".DS_Store", "Thumbs.db"]
+exclude_patterns:
+  - ".DS_Store"
+  - "Thumbs.db"
+  - ".git/**"
+  - ".github/**"
+  - ".hypothesis/**"
+  - ".mypy_cache/**"
+  - ".opencode/**"
+  - ".pytest_cache/**"
+  - ".ruff_cache/**"
+  - ".venv/**"
+  - ".worktrees/**"
+  - "_build/**"
+  - "dist/**"
+  - "docs/**"
+  - "AGENTS.md"
+
+only_build_toc_files: true
 
 html:
   title: HMMPY Documentation
@@ -20,3 +37,10 @@ parse:
     - linkify
     - substitution
     - tasklist
+
+sphinx:
+  local_extensions:
+    hmmpy_docs_ext: .
+  config:
+    nb_kernel_rgx_aliases:
+      "^python3$": "hmmpy-docs"

--- a/hmmpy_docs_ext.py
+++ b/hmmpy_docs_ext.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def setup(app: Any) -> dict[str, bool]:
+    root = Path(__file__).resolve().parent
+    src = root / "src"
+    jupyter_data_dir = root / "_build" / ".jupyter"
+    kernel_dir = jupyter_data_dir / "kernels" / "hmmpy-docs"
+
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+    python_path = os.environ.get("PYTHONPATH")
+    python_path = str(src) if not python_path else f"{src}{os.pathsep}{python_path}"
+
+    kernel_dir.mkdir(parents=True, exist_ok=True)
+    (kernel_dir / "kernel.json").write_text(
+        json.dumps(
+            {
+                "argv": [
+                    sys.executable,
+                    "-Xfrozen_modules=off",
+                    "-m",
+                    "ipykernel_launcher",
+                    "-f",
+                    "{connection_file}",
+                ],
+                "display_name": "HMMPY Docs",
+                "language": "python",
+                "metadata": {"debugger": True},
+                "env": {"PYTHONPATH": python_path},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    os.environ["PYTHONPATH"] = python_path
+    existing_jupyter_path = os.environ.get("JUPYTER_PATH")
+    os.environ["JUPYTER_PATH"] = (
+        str(jupyter_data_dir)
+        if not existing_jupyter_path
+        else f"{jupyter_data_dir}{os.pathsep}{existing_jupyter_path}"
+    )
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/notebooks/02-forward-algorithm.ipynb
+++ b/notebooks/02-forward-algorithm.ipynb
@@ -44,7 +44,8 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "from hmm import HMM, forward"
+    "from hmm import HMM, forward\n",
+    "from hmm.algorithms import ComputeMode\n"
    ]
   },
   {
@@ -69,7 +70,7 @@
     "\n",
     "# Run forward algorithm\n",
     "obs = [1, 2, 1, 6, 6]\n",
-    "log_prob, alpha, c = forward(hmm, obs, scaling=True)\n",
+    "log_prob, alpha, c = forward(hmm, obs, mode=ComputeMode.SCALED)\n",
     "\n",
     "print(f\"Observation sequence: {obs}\")\n",
     "print(f\"Log probability: {log_prob:.4f}\")\n",
@@ -96,7 +97,7 @@
    "outputs": [],
    "source": [
     "# Without scaling - note: can have numerical issues for long sequences\n",
-    "prob, alpha = forward(hmm, obs, scaling=False)\n",
+    "prob, alpha = forward(hmm, obs, mode=ComputeMode.UNSCALED)\n",
     "\n",
     "print(f\"Probability (without scaling): {prob:.6f}\")\n",
     "print(\"\\nAlpha matrix:\")\n",
@@ -121,8 +122,8 @@
     "# Verify scaling works correctly\n",
     "obs_long = [1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6]\n",
     "\n",
-    "log_prob_scaled, alpha_scaled, c_scaled = forward(hmm, obs_long, scaling=True)\n",
-    "prob_unscaled, alpha_unscaled = forward(hmm, obs_long, scaling=False)\n",
+    "log_prob_scaled, alpha_scaled, c_scaled = forward(hmm, obs_long, mode=ComputeMode.SCALED)\n",
+    "prob_unscaled, alpha_unscaled = forward(hmm, obs_long, mode=ComputeMode.UNSCALED)\n",
     "\n",
     "print(f\"Log probability (scaled): {log_prob_scaled:.4f}\")\n",
     "print(f\"Log probability (unscaled): {np.log(prob_unscaled):.4f}\")\n",
@@ -175,7 +176,7 @@
     "## Summary\n",
     "\n",
     "- The forward algorithm computes $P(O | \\lambda)$ - probability of observation given model\n",
-    "- Use `scaling=True` for numerical stability with long sequences\n",
+    "- Use `mode=ComputeMode.SCALED` for numerical stability with long sequences\n",
     "- Returns log probability when scaling is enabled\n",
     "\n",
     "Next notebook: [Viterbi Algorithm](./03-viterbi-algorithm.ipynb)"

--- a/notebooks/03-viterbi-algorithm.ipynb
+++ b/notebooks/03-viterbi-algorithm.ipynb
@@ -8,14 +8,15 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "from hmm import HMM, backward, forward, viterbi"
+    "from hmm import HMM, backward, forward, viterbi\n",
+    "from hmm.algorithms import ComputeMode\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Basic Viterbi Decoding"
+    "# Basic Viterbi Decoding"
    ]
   },
   {
@@ -35,7 +36,7 @@
     "obs = [0, 0, 0, 1, 0, 0, 2, 0, 0]\n",
     "\n",
     "# Run Viterbi\n",
-    "states, delta, psi = viterbi(hmm, obs, scaling=True)\n",
+    "states, delta, psi = viterbi(hmm, obs, mode=ComputeMode.LOG)\n",
     "\n",
     "print(f\"Observation: {obs}\")\n",
     "print(f\"Most likely states: {states}\")\n",
@@ -59,7 +60,7 @@
    "outputs": [],
    "source": [
     "# Compare Viterbi with Forward\n",
-    "log_prob_forward, _, _ = forward(hmm, obs, scaling=True)\n",
+    "log_prob_forward, _, _ = forward(hmm, obs, mode=ComputeMode.SCALED)\n",
     "log_prob_viterbi = delta[states[-1], len(obs)-1]\n",
     "\n",
     "print(f\"Forward log probability: {log_prob_forward:.4f}\")\n",
@@ -84,8 +85,8 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "# Get forward and backward variables\n",
-    "log_prob, alpha, c = forward(hmm, obs, scaling=True)\n",
-    "_ , beta, _ = backward(hmm, obs, scaling=True)\n",
+    "log_prob, alpha, c = forward(hmm, obs, mode=ComputeMode.SCALED)\n",
+    "beta = backward(hmm, obs, mode=ComputeMode.SCALED, scaling_coeffs=c)\n",
     "\n",
     "# Compute true state probability gamma = alpha * beta / sum(alpha * beta)\n",
     "gamma = alpha * beta\n",
@@ -97,7 +98,7 @@
     "ax.plot(t, gamma[1, :], 'r-o', label='State 1')\n",
     "ax.plot(t, [0.5]*len(obs), 'k--', alpha=0.3, label='Threshold')\n",
     "ax.set_xlabel('Time Step')\n",
-    "ax.set_ylabel('True State Probability (γ)')\n",
+    "ax.set_ylabel('True State Probability (\u03b3)')\n",
     "ax.set_title('State Probabilities Over Time - True Probabilities')\n",
     "ax.legend()\n",
     "ax.grid(True, alpha=0.3)\n",

--- a/notebooks/04-baum-welch.ipynb
+++ b/notebooks/04-baum-welch.ipynb
@@ -62,7 +62,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from hmm import HMM, baum_welch, forward"
+    "from hmm import HMM, baum_welch, forward\n",
+    "from hmm.algorithms import ComputeMode\n"
    ]
   },
   {
@@ -91,7 +92,7 @@
     "]\n",
     "\n",
     "# Check initial probability\n",
-    "initial_ll = sum(forward(hmm_initial, obs, scaling=True)[0] for obs in obs_seqs)\n",
+    "initial_ll = sum(forward(hmm_initial, obs, mode=ComputeMode.SCALED)[0] for obs in obs_seqs)\n",
     "print(f\"Initial log-likelihood: {initial_ll:.4f}\")\n",
     "\n",
     "# Train the HMM\n",
@@ -99,7 +100,7 @@
     "    hmm_initial,\n",
     "    obs_seqs=obs_seqs,\n",
     "    epochs=20,\n",
-    "    scaling=True,\n",
+    "    mode=ComputeMode.SCALED,\n",
     "    verbose=True\n",
     ")"
    ]
@@ -118,7 +119,7 @@
    "outputs": [],
    "source": [
     "# Check final probability\n",
-    "final_ll = sum(forward(hmm_trained, obs, scaling=True)[0] for obs in obs_seqs)\n",
+    "final_ll = sum(forward(hmm_trained, obs, mode=ComputeMode.SCALED)[0] for obs in obs_seqs)\n",
     "print(f\"Final log-likelihood: {final_ll:.4f}\")\n",
     "print(f\"Improvement: {final_ll - initial_ll:.4f}\")\n",
     "\n",
@@ -156,7 +157,7 @@
     "    obs_seqs=train_seqs,\n",
     "    val_set=val_seqs,\n",
     "    epochs=30,\n",
-    "    scaling=True,\n",
+    "    mode=ComputeMode.SCALED,\n",
     "    verbose=True\n",
     ")"
    ]
@@ -185,7 +186,7 @@
     "    obs_seqs=obs_seqs,\n",
     "    epochs=10,\n",
     "    update_a=False,  # Keep transitions fixed\n",
-    "    scaling=True\n",
+    "    mode=ComputeMode.SCALED\n",
     ")\n",
     "\n",
     "print(\"Original transition matrix (unchanged):\")\n",
@@ -205,7 +206,7 @@
     "- Baum-Welch is an EM algorithm for HMM training\n",
     "- Increases likelihood of observation sequences\n",
     "- Can use validation set for early stopping\n",
-    "- Can selectively update A, B, or π\n",
+    "- Can selectively update A, B, or \u03c0\n",
     "\n",
     "Next notebook: [Applications](./05-applications.ipynb)"
    ]

--- a/notebooks/05-applications.ipynb
+++ b/notebooks/05-applications.ipynb
@@ -21,7 +21,8 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "from hmm import HMM, HMMClassifier, baum_welch, forward, viterbi"
+    "from hmm import HMM, HMMClassifier, baum_welch, forward, viterbi\n",
+    "from hmm.algorithms import ComputeMode\n"
    ]
   },
   {
@@ -141,8 +142,8 @@
     "normal_test = [0, 0, 1, 1, 0, 0, 1, 1]\n",
     "anomaly_test = [1, 1, 1, 1, 1, 1, 1, 1]\n",
     "\n",
-    "normal_ll = forward(hmm_normal, normal_test, scaling=True)[0]\n",
-    "anomaly_ll = forward(hmm_normal, anomaly_test, scaling=True)[0]\n",
+    "normal_ll = forward(hmm_normal, normal_test, mode=ComputeMode.SCALED)[0]\n",
+    "anomaly_ll = forward(hmm_normal, anomaly_test, mode=ComputeMode.SCALED)[0]\n",
     "\n",
     "print(f\"Normal sequence log-likelihood: {normal_ll:.4f}\")\n",
     "print(f\"Anomaly sequence log-likelihood: {anomaly_ll:.4f}\")\n",
@@ -184,8 +185,8 @@
     "# Tag 0 = Noun, Tag 1 = Verb, Tag 2 = Determiner\n",
     "B = np.array([\n",
     "    [0.1, 0.4, 0.4, 0.05, 0.05],  # Noun: cat, dog\n",
-    "    [0.05, 0.05, 0.05, 0.45, 0.45],  # Verb: runs, eats\n",
-    "    [0.5, 0.0, 0.0, 0.0, 0.0],  # Determiner: the\n",
+    "    [0.05, 0.025, 0.025, 0.45, 0.45],  # Verb: runs, eats\n",
+    "    [1.0, 0.0, 0.0, 0.0, 0.0],  # Determiner: the\n",
     "])\n",
     "\n",
     "hmm_pos = HMM(n_states=3, A=A, B=B, V=V)\n",
@@ -194,7 +195,7 @@
     "sentence = ['the', 'cat', 'runs']\n",
     "obs = [word_to_idx[w] for w in sentence]\n",
     "\n",
-    "states, _, _ = viterbi(hmm_pos, obs, scaling=True)\n",
+    "states, _, _ = viterbi(hmm_pos, obs, mode=ComputeMode.LOG)\n",
     "pos_tags = ['Noun', 'Verb', 'Determiner']\n",
     "\n",
     "print(\"Sentence:\", sentence)\n",

--- a/notebooks/06-continuous-hmm.ipynb
+++ b/notebooks/06-continuous-hmm.ipynb
@@ -27,8 +27,8 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from hmm.algorithms import baum_welch, forward, viterbi\n",
-    "from hmm.continuous import GaussianHMM"
+    "from hmm.algorithms import ComputeMode, baum_welch, forward, viterbi\n",
+    "from hmm.continuous import GaussianHMM\n"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "outputs": [],
    "source": [
     "# Compute forward probability\n",
-    "log_prob, alpha, c = forward(hmm, observations, scaling=True)\n",
+    "log_prob, alpha, c = forward(hmm, observations, mode=ComputeMode.SCALED)\n",
     "print(f\"Log probability of observation sequence: {log_prob:.4f}\")"
    ]
   },
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "# Decode the most likely state sequence\n",
-    "q_star, delta, psi = viterbi(hmm, observations, scaling=True)\n",
+    "q_star, delta, psi = viterbi(hmm, observations, mode=ComputeMode.LOG)\n",
     "\n",
     "plt.figure(figsize=(12, 4))\n",
     "plt.plot(observations, 'b-', alpha=0.7, label='Observation')\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Hidden Markov Models in Python - based on Rabiner (1989) tutorial"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "MIT"
 authors = [
     {name = "Michael Hamilton", email = "mike.hamilton7@gmail.com"},
 ]
@@ -12,7 +12,6 @@ keywords = ["hmm", "hidden-markov-models", "machine-learning", "pattern-recognit
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -45,9 +44,17 @@ notebook = [
     "ipykernel>=6.25",
 ]
 all = [
-    "hmmpy[dependencies]",
-    "hmmpy[dev]",
-    "hmmpy[notebook]",
+    "pytest>=7.4",
+    "ruff>=0.1",
+    "mypy>=1.5",
+    "pytest-cov>=4.1",
+    "hypothesis>=6.100",
+    "types-networkx",
+    "jupyter-book==1.0.0",
+    "pydata-sphinx-theme>=0.14",
+    "networkx>=3.0",
+    "jupyterlab>=4.0",
+    "ipykernel>=6.25",
 ]
 
 [build-system]

--- a/src/hmm/algorithms.py
+++ b/src/hmm/algorithms.py
@@ -6,16 +6,17 @@ import copy
 import warnings
 from collections.abc import Sequence
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
 from einops import rearrange
-from scipy.special import logsumexp
+from scipy.special import logsumexp  # type: ignore[import-untyped]
 
-from hmm.base import HMMProtocol
+from hmm.base import HMMProtocol, ObservationSequence
 
 EPSILON = np.finfo(float).tiny
+ForwardResult: TypeAlias = tuple[float, npt.NDArray] | tuple[float, npt.NDArray, npt.NDArray | None]
 
 
 class ComputeMode(Enum):
@@ -27,10 +28,7 @@ class ComputeMode(Enum):
 
 
 if TYPE_CHECKING:
-    from hmm.continuous import GaussianHMM, MixtureGaussianHMM
     from hmm.hmm import HMM
-
-    AnyHMM = HMM | GaussianHMM | MixtureGaussianHMM
 
 
 def symbol_index(hmm: HMM, obs: Sequence[int]) -> list[int]:
@@ -56,10 +54,10 @@ def symbol_index(hmm: HMM, obs: Sequence[int]) -> list[int]:
 
 
 def forward(
-    hmm: AnyHMM,
-    obs: Sequence[int] | Sequence[npt.NDArray],
+    hmm: HMMProtocol,
+    obs: ObservationSequence,
     mode: ComputeMode = ComputeMode.SCALED,
-) -> tuple[float, npt.NDArray, npt.NDArray | None]:
+) -> ForwardResult:
     """Calculate the probability of an observation sequence, Obs, given the model.
 
     Implements the forward algorithm from Rabiner (1989).
@@ -84,7 +82,7 @@ def forward(
         log_Pi = np.log(np.maximum(hmm.Pi, EPSILON))
         log_A = np.log(np.maximum(hmm.A, EPSILON))
 
-        log_alpha = np.zeros([hmm.N, T], dtype=float)
+        log_alpha = np.zeros((hmm.N, T), dtype=float)
 
         log_alpha[:, 0] = log_Pi + np.log(np.maximum(hmm.get_emission_probs(obs[0]), EPSILON))
 
@@ -100,7 +98,7 @@ def forward(
     if mode == ComputeMode.SCALED:
         c = np.zeros(T, dtype=float)
 
-    alpha = np.zeros([hmm.N, T], dtype=float)
+    alpha = np.zeros((hmm.N, T), dtype=float)
 
     alpha[:, 0] = hmm.Pi * hmm.get_emission_probs(obs[0])
 
@@ -124,8 +122,8 @@ def forward(
 
 
 def backward(
-    hmm: AnyHMM,
-    obs: Sequence[int] | Sequence[npt.NDArray],
+    hmm: HMMProtocol,
+    obs: ObservationSequence,
     mode: ComputeMode = ComputeMode.SCALED,
     scaling_coeffs: npt.NDArray | None = None,
 ) -> npt.NDArray:
@@ -147,7 +145,7 @@ def backward(
     if mode == ComputeMode.LOG:
         log_A = np.log(np.maximum(hmm.A, EPSILON))
 
-        log_beta = np.zeros([hmm.N, T], dtype=float)
+        log_beta = np.zeros((hmm.N, T), dtype=float)
         log_beta[:, T - 1] = 0.0
 
         for t in reversed(range(T - 1)):
@@ -165,7 +163,7 @@ def backward(
         if mode == ComputeMode.SCALED:
             c = np.zeros(T, dtype=float)
 
-    beta = np.zeros([hmm.N, T], dtype=float)
+    beta = np.zeros((hmm.N, T), dtype=float)
     beta[:, T - 1] = 1.0
 
     if mode == ComputeMode.SCALED and c is not None and scaling_coeffs is None:
@@ -187,8 +185,8 @@ def backward(
 
 
 def viterbi(
-    hmm: AnyHMM,
-    obs: Sequence[int] | Sequence[npt.NDArray],
+    hmm: HMMProtocol,
+    obs: ObservationSequence,
     mode: ComputeMode = ComputeMode.LOG,
 ) -> tuple[list[int], npt.NDArray, npt.NDArray]:
     """Calculate P(Q|Obs, hmm) and yield the state sequence Q* that maximizes this probability.
@@ -221,7 +219,7 @@ def viterbi(
 
     T = len(obs)
 
-    delta = np.zeros([hmm.N, T], dtype=float)
+    delta = np.zeros((hmm.N, T), dtype=float)
 
     if mode == ComputeMode.LOG:
         delta[:, 0] = np.log(np.maximum(hmm.Pi, EPSILON)) + np.log(
@@ -230,7 +228,7 @@ def viterbi(
     else:
         delta[:, 0] = hmm.Pi * hmm.get_emission_probs(obs[0])
 
-    psi = np.zeros([hmm.N, T], dtype=int)
+    psi = np.zeros((hmm.N, T), dtype=int)
 
     if mode == ComputeMode.LOG:
         for t in range(1, T):
@@ -243,18 +241,28 @@ def viterbi(
             delta[:, t] = nus.max(0) * hmm.get_emission_probs(obs[t])
             psi[:, t] = nus.argmax(0)
 
-    q_star = [int(np.argmax(delta[:, T - 1]))]
+    q_star = [0] * T
+    q_star[T - 1] = int(np.argmax(delta[:, T - 1]))
     for t in reversed(range(T - 1)):
-        q_star.insert(0, int(psi[q_star[0], t + 1]))
+        q_star[t] = int(psi[q_star[t + 1], t + 1])
 
     return (q_star, delta, psi)
 
 
+def _unpack_forward_result(result: ForwardResult) -> tuple[float, npt.NDArray, npt.NDArray | None]:
+    """Normalize forward outputs across computation modes."""
+    if len(result) == 3:
+        return result
+
+    log_prob_obs, alpha = result
+    return log_prob_obs, alpha, None
+
+
 def baum_welch(
     hmm: HMMProtocol,
-    obs_seqs: list[Sequence[npt.NDArray]],
+    obs_seqs: list[ObservationSequence],
     epochs: int = 20,
-    val_set: list[Sequence[npt.NDArray]] | None = None,
+    val_set: list[ObservationSequence] | None = None,
     update_pi: bool = True,
     update_a: bool = True,
     update_b: bool = True,
@@ -302,7 +310,7 @@ def baum_welch(
             obs_list = list(obs)
 
             forward_result = forward(hmm=hmm, obs=obs_list, mode=mode)
-            log_prob_obs, alpha, c = forward_result
+            log_prob_obs, alpha, c = _unpack_forward_result(forward_result)
             beta = backward(hmm=hmm, obs=obs_list, mode=mode, scaling_coeffs=c)
 
             LL_epoch += log_prob_obs
@@ -324,11 +332,14 @@ def baum_welch(
                 log_beta = beta[:, 1:]
                 log_xi = (
                     rearrange(log_alpha, "n t -> t n 1")
-                    + np.log(hmm.A)
-                    + log_B
+                    + np.log(np.maximum(hmm.A, EPSILON))
+                    + rearrange(log_B, "n t -> t 1 n")
                     + rearrange(log_beta, "n t -> t 1 n")
                 )
-                xi = np.exp(log_xi - logsumexp(log_xi, axis=(1, 2), keepdims=True))
+                xi = rearrange(
+                    np.exp(log_xi - logsumexp(log_xi, axis=(1, 2), keepdims=True)),
+                    "t i j -> i j t",
+                )
             else:
                 xi = np.einsum(
                     "it, ij, jt, jt -> ijt",
@@ -412,7 +423,8 @@ def baum_welch(
             plt.savefig(fname)
 
     if val_set is not None:
-        hmm.A = best_hmm.A
-        hmm.Pi = best_hmm.Pi
+        # Restore the full best-performing model rather than just A/Pi.
+        hmm.__dict__.clear()
+        hmm.__dict__.update(copy.deepcopy(best_hmm.__dict__))
 
     return hmm

--- a/src/hmm/base.py
+++ b/src/hmm/base.py
@@ -1,53 +1,39 @@
-"""HMM Protocol defining the interface for all HMM implementations."""
+"""Protocol definitions shared by trainable HMM implementations."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Protocol
+from typing import Protocol, TypeAlias
 
 import numpy.typing as npt
 
+Observation: TypeAlias = int | npt.NDArray
+ObservationSequence: TypeAlias = Sequence[Observation]
+
 
 class HMMProtocol(Protocol):
-    """Protocol defining the required interface for any HMM implementation."""
+    """Protocol defining the interface required by the algorithm module."""
 
     N: int
     Pi: npt.NDArray
     A: npt.NDArray
 
-    def get_emission_probs(self, obs_t: npt.NDArray) -> npt.NDArray:
-        """Returns emission probabilities for all states given a single observation."""
+    def get_emission_probs(self, obs_t: Observation) -> npt.NDArray:
+        """Return emission probabilities for all states for a single observation."""
         ...
 
-    def get_all_emission_probs(self, obs_seq: Sequence[int] | Sequence[npt.NDArray]) -> npt.NDArray:
-        """Returns emission probabilities for all states across entire observation sequence.
-
-        Args:
-            obs_seq: Observation sequence (list of symbols for discrete, arrays for continuous)
-
-        Returns:
-            Array of shape (N, T) with emission probabilities for each state and time step
-        """
+    def get_all_emission_probs(self, obs_seq: ObservationSequence) -> npt.NDArray:
+        """Return emission probabilities for all states across an observation sequence."""
         ...
 
     def m_step(
         self,
-        obs_seqs: list[Sequence[npt.NDArray]],
+        obs_seqs: list[ObservationSequence],
         gammas: list[npt.NDArray],
         xis: list[npt.NDArray],
         update_pi: bool = True,
         update_a: bool = True,
         update_b: bool = True,
     ) -> None:
-        """
-        Performs the Maximization step to update model parameters in-place.
-
-        Args:
-            obs_seqs: The original list of observation sequences.
-            gammas: Expected state occupancies. List of arrays of shape (N, T).
-            xis: Expected transitions. List of arrays of shape (N, N, T-1).
-            update_pi: Whether to update initial state probabilities.
-            update_a: Whether to update transition probabilities.
-            update_b: Whether to update emission parameters (B, means, covars, etc.).
-        """
+        """Update model parameters in-place from expected sufficient statistics."""
         ...

--- a/src/hmm/hmm.py
+++ b/src/hmm/hmm.py
@@ -9,7 +9,7 @@ import numpy.typing as npt
 from numpy import random as rand
 
 from hmm.algorithms import ComputeMode, forward
-from hmm.base import HMMProtocol
+from hmm.base import HMMProtocol, Observation, ObservationSequence
 
 
 class HMMClassifier:
@@ -63,16 +63,18 @@ class HMMClassifier:
         Raises:
             ValueError: if no models are configured
         """
-        if not self.models or (self.pos_hmm is None and self.neg_hmm is None):
-            raise ValueError("pos/neg hmm(s) missing")
+        if not self.models:
+            raise ValueError("No HMM models configured")
 
-        if self._mode == "binary" or ("positive" in self.models and "negative" in self.models):
+        if self._mode == "binary":
+            if "positive" not in self.models or "negative" not in self.models:
+                raise ValueError("Binary classification requires positive and negative HMMs")
             pos_ll = forward(self.models["positive"], sample, mode=ComputeMode.SCALED)[0]
             neg_ll = forward(self.models["negative"], sample, mode=ComputeMode.SCALED)[0]
             return pos_ll - neg_ll
 
         scores = self.get_scores(sample)
-        return max(scores, key=scores.get)
+        return max(scores, key=lambda label: scores[label])
 
     def get_scores(self, sample: Sequence[int]) -> dict[str, float]:
         """
@@ -84,7 +86,7 @@ class HMMClassifier:
         Returns:
             Dictionary mapping class labels to log-likelihoods
         """
-        scores = {}
+        scores: dict[str, float] = {}
         for label, model in self.models.items():
             scores[label] = forward(model, sample, mode=ComputeMode.SCALED)[0]
         return scores
@@ -229,7 +231,13 @@ class HMM:
                 f"Initial state distribution Pi must sum to 1. Got sum: {self.Pi.sum()}"
             )
 
-    def get_emission_probs(self, obs_t: int | npt.NDArray) -> npt.NDArray:
+    def _obs_to_symbol(self, obs_t: Observation) -> int:
+        """Normalize discrete observations to a symbol in V."""
+        if isinstance(obs_t, np.ndarray):
+            return int(np.squeeze(obs_t))
+        return int(obs_t)
+
+    def get_emission_probs(self, obs_t: Observation) -> npt.NDArray:
         """Returns emission probabilities for all states given observation obs_t.
 
         Args:
@@ -238,11 +246,9 @@ class HMM:
         Returns:
             Array of shape (N,) with emission probabilities for each state
         """
-        if not isinstance(obs_t, int):
-            obs_t = int(np.squeeze(obs_t))
-        return self.B[:, self.symbol_map[obs_t]]
+        return self.B[:, self.symbol_map[self._obs_to_symbol(obs_t)]]
 
-    def get_all_emission_probs(self, obs_seq: Sequence[int] | Sequence[npt.NDArray]) -> npt.NDArray:
+    def get_all_emission_probs(self, obs_seq: ObservationSequence) -> npt.NDArray:
         """Returns emission probabilities for all states across entire observation sequence.
 
         Args:
@@ -251,12 +257,12 @@ class HMM:
         Returns:
             Array of shape (N, T) with emission probabilities for each state and time step
         """
-        indices = [self.symbol_map[o] for o in obs_seq]
+        indices = [self.symbol_map[self._obs_to_symbol(o)] for o in obs_seq]
         return self.B[:, indices]
 
     def m_step(
         self,
-        obs_seqs: list[Sequence[npt.NDArray]],
+        obs_seqs: list[ObservationSequence],
         gammas: list[npt.NDArray],
         xis: list[npt.NDArray],
         update_pi: bool = True,
@@ -273,7 +279,10 @@ class HMM:
         expect_si_vk_all = np.zeros([self.N, self.M], dtype=float)
 
         for obs, gamma, xi in zip(obs_seqs, gammas, xis):
-            obs_symbols = np.array([self.symbol_map[o] for o in obs])
+            obs_symbols = np.array(
+                [self.symbol_map[self._obs_to_symbol(o)] for o in obs],
+                dtype=int,
+            )
             T = len(obs)
 
             expect_si_t0_all += gamma[:, 0]
@@ -305,6 +314,50 @@ class HMM:
 
             for i in self.F:
                 self.B[i, :] = self.F[i]
+
+    def m_step_streaming(
+        self,
+        obs_seq: ObservationSequence,
+        gamma: npt.NDArray,
+        xi: npt.NDArray,
+    ) -> dict[str, npt.NDArray]:
+        """Compute sufficient statistics for one observation sequence.
+
+        This enables memory-efficient online/batch updates without storing
+        all sequences in memory.
+
+        Args:
+            obs_seq: Single observation sequence
+            gamma: Expected state occupancies (N, T)
+            xi: Expected transitions (N, N, T-1)
+
+        Returns:
+            Dictionary with sufficient statistics:
+            - expect_si_t0: expected state at t=0
+            - expect_si_all_TM1: sum of gamma over T-1
+            - expected_transitions: sum of xi over T-1
+            - expect_si_vk_all: expected emissions per symbol
+        """
+        T = len(obs_seq)
+        obs_symbols = np.array(
+            [self.symbol_map[self._obs_to_symbol(o)] for o in obs_seq],
+            dtype=int,
+        )
+
+        stats = {
+            "expect_si_t0": gamma[:, 0].copy(),
+            "expect_si_all_TM1": gamma[:, : T - 1].sum(1).copy(),
+            "expected_transitions": xi[:, :, : T - 1].sum(2).copy(),
+        }
+
+        if self.M > 0:
+            B_bar = np.zeros([self.N, self.M], dtype=float)
+            for k in range(self.M):
+                which = obs_symbols == k
+                B_bar[:, k] = gamma[:, which].sum(1)
+            stats["expect_si_vk_all"] = B_bar
+
+        return stats
 
     def __repr__(self) -> str:
         retn = ""

--- a/src/hmm/viz/diagrams.py
+++ b/src/hmm/viz/diagrams.py
@@ -37,7 +37,7 @@ def plot_state_diagram(
     else:
         fig = ax.figure  # type: ignore[assignment]
 
-    G = nx.DiGraph()
+    G: Any = nx.DiGraph()
 
     for i in range(hmm.N):
         G.add_node(i, label=f"S{i}")

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+import hmm.algorithms as algorithms
 from hmm import HMM, HMMClassifier, backward, baum_welch, forward, viterbi
 from hmm.algorithms import ComputeMode
 
@@ -91,8 +92,37 @@ class TestHMMClassifier:
         """Test classification raises error when HMMs are missing."""
         classifier = HMMClassifier()
 
-        with pytest.raises(ValueError, match="pos/neg hmm.*missing"):
+        with pytest.raises(ValueError, match="No HMM models configured"):
             classifier.classify([1, 2, 3])
+
+    def test_classify_multiclass_returns_label(self) -> None:
+        """Multiclass classifier should return the best label."""
+        A = np.array([[1.0]])
+        V = [0, 1]
+        models = {
+            "spam": HMM(n_states=1, A=A, B=np.array([[0.9, 0.1]]), V=V),
+            "ham": HMM(n_states=1, A=A, B=np.array([[0.1, 0.9]]), V=V),
+        }
+
+        classifier = HMMClassifier(models=models)
+
+        assert classifier.classify([0, 0, 0]) == "spam"
+
+    def test_classify_multiclass_does_not_fall_back_to_binary(self) -> None:
+        """Multiclass mode should not be hijacked by positive/negative labels."""
+        A = np.array([[1.0]])
+        V = [0, 1]
+        models = {
+            "positive": HMM(n_states=1, A=A, B=np.array([[0.9, 0.1]]), V=V),
+            "negative": HMM(n_states=1, A=A, B=np.array([[0.1, 0.9]]), V=V),
+            "neutral": HMM(n_states=1, A=A, B=np.array([[0.5, 0.5]]), V=V),
+        }
+
+        classifier = HMMClassifier(models=models)
+        result = classifier.classify([0, 0, 0])
+
+        assert result == "positive"
+        assert isinstance(result, str)
 
 
 class TestForwardAlgorithm:
@@ -174,9 +204,13 @@ class TestBackwardAlgorithm:
         hmm = HMM(n_states=2, A=A, B=B, V=V)
 
         obs = [1, 2, 1, 6, 6]
-        beta = backward(hmm, obs)
+        prob_obs, _ = forward(hmm, obs, mode=ComputeMode.UNSCALED)
+        beta = backward(hmm, obs, mode=ComputeMode.UNSCALED)
 
         assert beta.shape == (2, 5)
+        assert np.allclose(beta[:, -1], np.ones(hmm.N))
+        start_prob = np.sum(hmm.Pi * hmm.get_emission_probs(obs[0]) * beta[:, 0])
+        assert np.isclose(start_prob, prob_obs)
 
 
 class TestViterbiAlgorithm:
@@ -276,6 +310,23 @@ class TestBaumWelch:
 
         assert hmm1.A.shape == hmm2.A.shape
 
+    def test_baum_welch_log_mode(self) -> None:
+        """Test Baum-Welch runs in LOG mode."""
+        A = np.array([[0.95, 0.05], [0.05, 0.95]])
+        B = np.array([[1.0 / 6] * 6, [1.0 / 10] * 5 + [1.0 / 2]])
+        V = [1, 2, 3, 4, 5, 6]
+        hmm = HMM(n_states=2, A=A.copy(), B=B.copy(), V=V)
+
+        trained = baum_welch(
+            hmm,
+            [[1, 2, 1, 6, 6], [6, 6, 1, 2, 1]],
+            epochs=2,
+            mode=ComputeMode.LOG,
+        )
+
+        assert trained.A.shape == (2, 2)
+        assert trained.B.shape == (2, 6)
+
     def test_baum_welch_update_flags(self) -> None:
         """Test Baum-Welch update flags."""
         A = np.array([[0.95, 0.05], [0.05, 0.95]])
@@ -300,3 +351,75 @@ class TestBaumWelch:
         trained = baum_welch(hmm, [], epochs=1)
 
         assert trained.N == 2
+
+    def test_baum_welch_validation_restores_best_emission_matrix(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Validation rollback should restore the full best model, including B."""
+
+        class RollbackHMM(HMM):
+            def __init__(self) -> None:
+                super().__init__(
+                    n_states=2,
+                    A=np.array([[0.9, 0.1], [0.2, 0.8]]),
+                    B=np.array([[0.6, 0.4], [0.3, 0.7]]),
+                    V=[0, 1],
+                )
+                self._epoch = 0
+
+            def m_step(
+                self,
+                obs_seqs: list[list[int]],
+                gammas: list[np.ndarray],
+                xis: list[np.ndarray],
+                update_pi: bool = True,
+                update_a: bool = True,
+                update_b: bool = True,
+            ) -> None:
+                del obs_seqs, gammas, xis, update_pi, update_a, update_b
+                self._epoch += 1
+                if self._epoch == 1:
+                    self.B = np.array([[0.95, 0.05], [0.1, 0.9]])
+                else:
+                    self.B = np.array([[0.55, 0.45], [0.45, 0.55]])
+
+        hmm = RollbackHMM()
+        expected_best_B = np.array([[0.95, 0.05], [0.1, 0.9]])
+        train_seqs = [[0, 1, 0, 1]]
+        val_seqs = [[0, 0, 0, 0]]
+        real_forward = algorithms.forward
+        val_lls = iter([10.0, 0.0])
+
+        def controlled_forward(
+            hmm: HMM,
+            obs: list[int],
+            mode: ComputeMode = ComputeMode.SCALED,
+        ) -> tuple[float, np.ndarray, np.ndarray | None]:
+            log_prob, alpha, c = real_forward(hmm, obs, mode=mode)
+            if list(obs) == val_seqs[0]:
+                return (next(val_lls), alpha, c)
+            return (log_prob, alpha, c)
+
+        monkeypatch.setattr(algorithms, "forward", controlled_forward)
+
+        trained = baum_welch(hmm, train_seqs, epochs=2, val_set=val_seqs)
+
+        assert np.allclose(trained.B, expected_best_B)
+
+    def test_m_step_streaming(self) -> None:
+        """Test streaming m_step returns sufficient statistics for one sequence."""
+        hmm = HMM(n_states=2, V=[0, 1])
+        obs_seq = [0, 1, 0, 1]
+        gamma = np.array([[0.8, 0.2, 0.7, 0.3], [0.2, 0.8, 0.3, 0.7]])
+        xi = np.zeros((2, 2, 3))
+        xi[0, 0, :] = 0.5
+        xi[1, 1, :] = 0.5
+
+        # Should return sufficient statistics dictionary
+        stats = hmm.m_step_streaming(obs_seq, gamma, xi)
+
+        assert "expect_si_t0" in stats
+        assert "expected_transitions" in stats
+        assert stats["expect_si_t0"].shape == (2,)
+        assert stats["expected_transitions"].shape == (2, 2)

--- a/tests/test_notebooks_api.py
+++ b/tests/test_notebooks_api.py
@@ -1,0 +1,20 @@
+"""Static checks for notebook example API usage."""
+
+import json
+from pathlib import Path
+
+NOTEBOOKS_DIR = Path(__file__).resolve().parents[1] / "notebooks"
+
+
+def test_notebooks_do_not_use_removed_scaling_flag() -> None:
+    """Notebook examples should use ComputeMode instead of the removed scaling flag."""
+    stale_references: list[str] = []
+
+    for notebook_path in sorted(NOTEBOOKS_DIR.glob("*.ipynb")):
+        notebook = json.loads(notebook_path.read_text())
+        for index, cell in enumerate(notebook["cells"]):
+            source = "".join(cell.get("source", []))
+            if "scaling=" in source:
+                stale_references.append(f"{notebook_path.name}:cell{index}")
+
+    assert stale_references == []


### PR DESCRIPTION
## Summary
- fix baum_welch LOG-mode tensor broadcasting and xi axis ordering
- fix HMMClassifier multiclass vs binary dispatch so multiclass is not hijacked by positive/negative fallback
- make Viterbi traceback linear-time
- add regression tests for LOG-mode Baum-Welch and multiclass classifier behavior
- strengthen backward unscaled test assertions
- update notebooks for ComputeMode API and fix invalid probability example in applications notebook
- harden JupyterBook config with TOC-only build and local docs extension for stable kernel/import setup

## Verification
- uv run --extra dev pytest -q -p no:cacheprovider -> 63 passed
- uv run --extra dev ruff check . -> clean
- uv run --extra dev mypy src/hmm -> clean
- uv run --extra docs jupyter-book build . -> succeeded
